### PR TITLE
Update BindToSocketAndWriteQuery method for Win8.1

### DIFF
--- a/Zeroconf.RT/NetworkInterface.cs
+++ b/Zeroconf.RT/NetworkInterface.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Windows.Foundation;
 using Windows.Networking;
+using Windows.Networking.Connectivity;
 using Windows.Networking.Sockets;
 using Windows.Storage.Streams;
 
@@ -81,7 +82,7 @@ namespace Zeroconf.Platform
 
         private static async Task BindToSocketAndWriteQuery(DatagramSocket socket, byte[] bytes, CancellationToken cancellationToken)
         {
-            await socket.BindServiceNameAsync("5353")
+            await socket.BindServiceNameAsync("", NetworkInformation.GetInternetConnectionProfile().NetworkAdapter)
                         .AsTask(cancellationToken)
                         .ConfigureAwait(false);
 


### PR DESCRIPTION
Because of this problem : http://blogs.msdn.com/b/wsdevsol/archive/2013/12/19/datagramsocket-multicast-functionality-on-windows-8-1-throws-an-error-0x80072af9-wsahost-not-found.aspx, it didn't work under Windows 8.1.
