### PR TITLE
Target Windows Phone 8.1

### DIFF
--- a/Zeroconf.WP8.1/Properties/AssemblyInfo.cs
+++ b/Zeroconf.WP8.1/Properties/AssemblyInfo.cs
@@ -1,0 +1,17 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Resources;
+
+
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("71071865-9dce-472e-a8b3-d9d44c5cf23f")]
+
+
+[assembly: NeutralResourcesLanguage("en-US")]

--- a/Zeroconf.WP8.1/Zeroconf.WP8.1.csproj
+++ b/Zeroconf.WP8.1/Zeroconf.WP8.1.csproj
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>10.0.20506</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{64836093-A02D-4B17-BA29-717B9AAC0728}</ProjectGuid>
+    <ProjectTypeGuids>{C089C8C0-30E0-4E22-80C0-CE093F111A43};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Zeroconf.Platform</RootNamespace>
+    <AssemblyName>Zeroconf.Platform</AssemblyName>
+    <TargetFrameworkIdentifier>WindowsPhone</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <SilverlightVersion>
+    </SilverlightVersion>
+    <SilverlightApplication>false</SilverlightApplication>
+    <ValidateXaml>true</ValidateXaml>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
+    <ThrowErrorsInValidation>true</ThrowErrorsInValidation>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
+    <DefaultLanguage>en-US</DefaultLanguage>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>Bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;TRACE;SILVERLIGHT;WINDOWS_PHONE</DefineConstants>
+    <NoStdLib>true</NoStdLib>
+    <NoConfig>true</NoConfig>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>Bin\Release</OutputPath>
+    <DefineConstants>TRACE;SILVERLIGHT;WINDOWS_PHONE</DefineConstants>
+    <NoStdLib>true</NoStdLib>
+    <NoConfig>true</NoConfig>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>Bin\Release\Zeroconf.Platform.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>Bin\x86\Debug</OutputPath>
+    <DefineConstants>DEBUG;TRACE;SILVERLIGHT;WINDOWS_PHONE</DefineConstants>
+    <NoStdLib>true</NoStdLib>
+    <NoConfig>true</NoConfig>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>Bin\x86\Release</OutputPath>
+    <DefineConstants>TRACE;SILVERLIGHT;WINDOWS_PHONE</DefineConstants>
+    <NoStdLib>true</NoStdLib>
+    <NoConfig>true</NoConfig>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|ARM' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>Bin\ARM\Debug</OutputPath>
+    <DefineConstants>DEBUG;TRACE;SILVERLIGHT;WINDOWS_PHONE</DefineConstants>
+    <NoStdLib>true</NoStdLib>
+    <NoConfig>true</NoConfig>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|ARM' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>Bin\ARM\Release</OutputPath>
+    <DefineConstants>TRACE;SILVERLIGHT;WINDOWS_PHONE</DefineConstants>
+    <NoStdLib>true</NoStdLib>
+    <NoConfig>true</NoConfig>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget />
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\Zeroconf.RT\NetworkInterface.cs">
+      <Link>NetworkInterface.cs</Link>
+    </Compile>
+    <Compile Include="..\Zeroconf.RT\Properties\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Zeroconf\Zeroconf.csproj">
+      <Project>{5EA8CE38-6134-4263-9292-8798C7585622}</Project>
+      <Name>Zeroconf</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\$(TargetFrameworkIdentifier)\$(TargetFrameworkVersion)\Microsoft.$(TargetFrameworkIdentifier).$(TargetFrameworkVersion).Overrides.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\$(TargetFrameworkIdentifier)\$(TargetFrameworkVersion)\Microsoft.$(TargetFrameworkIdentifier).CSharp.targets" />
+  <ProjectExtensions />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Zeroconf.sln
+++ b/Zeroconf.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.20827.3
+VisualStudioVersion = 12.0.30324.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Zeroconf.RT", "Zeroconf.RT\Zeroconf.RT.csproj", "{B3534F12-4701-4193-83EE-FAD2C4F9A629}"
 EndProject
@@ -30,6 +30,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Zeroconf", "Zeroconf\Zeroconf.csproj", "{5EA8CE38-6134-4263-9292-8798C7585622}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Test Apps", "Test Apps", "{3E523ACF-A6BA-4087-A736-5120415898BA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Zeroconf.WP8.1", "Zeroconf.WP8.1\Zeroconf.WP8.1.csproj", "{64836093-A02D-4B17-BA29-717B9AAC0728}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -147,13 +149,27 @@ Global
 		{5EA8CE38-6134-4263-9292-8798C7585622}.Release|ARM.ActiveCfg = Release|Any CPU
 		{5EA8CE38-6134-4263-9292-8798C7585622}.Release|x64.ActiveCfg = Release|Any CPU
 		{5EA8CE38-6134-4263-9292-8798C7585622}.Release|x86.ActiveCfg = Release|Any CPU
+		{64836093-A02D-4B17-BA29-717B9AAC0728}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{64836093-A02D-4B17-BA29-717B9AAC0728}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{64836093-A02D-4B17-BA29-717B9AAC0728}.Debug|ARM.ActiveCfg = Debug|ARM
+		{64836093-A02D-4B17-BA29-717B9AAC0728}.Debug|ARM.Build.0 = Debug|ARM
+		{64836093-A02D-4B17-BA29-717B9AAC0728}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{64836093-A02D-4B17-BA29-717B9AAC0728}.Debug|x86.ActiveCfg = Debug|x86
+		{64836093-A02D-4B17-BA29-717B9AAC0728}.Debug|x86.Build.0 = Debug|x86
+		{64836093-A02D-4B17-BA29-717B9AAC0728}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{64836093-A02D-4B17-BA29-717B9AAC0728}.Release|Any CPU.Build.0 = Release|Any CPU
+		{64836093-A02D-4B17-BA29-717B9AAC0728}.Release|ARM.ActiveCfg = Release|ARM
+		{64836093-A02D-4B17-BA29-717B9AAC0728}.Release|ARM.Build.0 = Release|ARM
+		{64836093-A02D-4B17-BA29-717B9AAC0728}.Release|x64.ActiveCfg = Release|Any CPU
+		{64836093-A02D-4B17-BA29-717B9AAC0728}.Release|x86.ActiveCfg = Release|x86
+		{64836093-A02D-4B17-BA29-717B9AAC0728}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{E1424569-4A10-4164-A99B-A3EBC7AFD469} = {3E523ACF-A6BA-4087-A736-5120415898BA}
 		{98FDD85C-97C5-4C49-9CFD-E17498F194DB} = {3E523ACF-A6BA-4087-A736-5120415898BA}
 		{659B4C97-FDF2-4311-ACE8-14504036C4D6} = {3E523ACF-A6BA-4087-A736-5120415898BA}
+		{E1424569-4A10-4164-A99B-A3EBC7AFD469} = {3E523ACF-A6BA-4087-A736-5120415898BA}
 	EndGlobalSection
 EndGlobal

--- a/nuget/Zeroconf.nuspec
+++ b/nuget/Zeroconf.nuspec
@@ -9,7 +9,7 @@
         <licenseUrl>http://opensource.org/licenses/ms-pl</licenseUrl>
         <projectUrl>https://github.com/onovotny/Zeroconf</projectUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>Bonjour support for .NET 4.5, Windows Phone 8 and Windows Store apps with PCL support</description>
+        <description>Bonjour support for .NET 4.5, Windows Phone 8 and 8.1, and Windows Store apps with PCL support</description>
         <copyright>© Oren Novotny 2013</copyright>
         <language>en-US</language>
         <tags>zeroconf bonjour mdns service discovery pcl</tags>
@@ -31,6 +31,14 @@
       <file src="..\Zeroconf\Bin\Release\Zeroconf.dll" target="lib\wp8\Zeroconf.dll" />
       <file src="..\Zeroconf\Bin\Release\Zeroconf.pdb" target="lib\wp8\Zeroconf.pdb" />
       <file src="..\Zeroconf\Bin\Release\Zeroconf.xml" target="lib\wp8\Zeroconf.xml" />
+	  
+	        <!-- WP8.1 -->
+      <file src="..\Zeroconf.WP8.1\Bin\Release\Zeroconf.Platform.dll" target="lib\wpa81\Zeroconf.Platform.dll" />
+      <file src="..\Zeroconf.WP8.1\Bin\Release\Zeroconf.Platform.pdb" target="lib\wpa81\Zeroconf.Platform.pdb" />
+      <file src="..\Zeroconf.WP8.1\Bin\Release\Zeroconf.Platform.xml" target="lib\wpa81\Zeroconf.Platform.xml" />
+      <file src="..\Zeroconf\Bin\Release\Zeroconf.dll" target="lib\wpa81\Zeroconf.dll" />
+      <file src="..\Zeroconf\Bin\Release\Zeroconf.pdb" target="lib\wpa81\Zeroconf.pdb" />
+      <file src="..\Zeroconf\Bin\Release\Zeroconf.xml" target="lib\wpa81\Zeroconf.xml" />
       
       <!-- Net45 -->  
       <file src="..\Zeroconf.NetFX\Bin\Release\Zeroconf.Platform.dll" target="lib\net45\Zeroconf.Platform.dll" />


### PR DESCRIPTION
I'm using Zeroconf in a Windows Phone application that I want to target Windows Phone 8.1 with. Zeroconf currently doesn't target WP8.1 and generated an error when I tried installing it, so I added a new project within the Zeroconf solution that targets 8.1. 
I also changed the NuGet package spec so that users can add the package to their WP8.1 project. 

Verified locally that the package works and that no underlying source code changes are required. 
Example: Enumerating machines without regression in WP 8.1 project (still works as you'd expect)
![image](https://cloud.githubusercontent.com/assets/1258037/3557455/8b91d972-092f-11e4-8419-0143186b87c5.png)

Package description now says it also targets 8.1:
![image](https://cloud.githubusercontent.com/assets/1258037/3557472/ccb2856e-092f-11e4-8754-63b493a399d8.png)
