### PR TITLE
Access on adaper crashes at the second time execution on Nougat

### DIFF
--- a/Zeroconf/Platforms/netstandard1.3/NetworkInterface.cs
+++ b/Zeroconf/Platforms/netstandard1.3/NetworkInterface.cs
@@ -51,7 +51,7 @@ namespace Zeroconf
             //if (!adapter.GetIPProperties().MulticastAddresses.Any())
             //    return; // most of VPN adapters will be skipped
 #if __ANDROID_24__
-            var prova = "";
+            
 #else
             if (!adapter.SupportsMulticast)
                 return; // multicast is meaningless for this type of connection

--- a/Zeroconf/Platforms/netstandard1.3/NetworkInterface.cs
+++ b/Zeroconf/Platforms/netstandard1.3/NetworkInterface.cs
@@ -50,12 +50,16 @@ namespace Zeroconf
             // Xamarin doesn't support this
             //if (!adapter.GetIPProperties().MulticastAddresses.Any())
             //    return; // most of VPN adapters will be skipped
-
+#if __ANDROID_24__
+            var prova = "";
+#else
             if (!adapter.SupportsMulticast)
                 return; // multicast is meaningless for this type of connection
 
             if (OperationalStatus.Up != adapter.OperationalStatus)
                 return; // this adapter is off or not connected
+#endif
+
 
             if (adapter.NetworkInterfaceType == NetworkInterfaceType.Loopback)
                 return; // strip out loopback addresses

--- a/Zeroconf/Zeroconf.csproj
+++ b/Zeroconf/Zeroconf.csproj
@@ -17,6 +17,9 @@
     <TargetPlatformVersion Condition="'$(TargetFramework)' == 'uap10.0'">10.0.14393.0</TargetPlatformVersion>
     <TargetPlatformMinVersion Condition="'$(TargetFramework)' == 'uap10.0'">10.0.10586.0</TargetPlatformMinVersion>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard1.3|AnyCPU'">
+    <DefineConstants>TRACE;DEBUG;NETSTANDARD1_3; __ANDROID_24__</DefineConstants>
+  </PropertyGroup>
 
   <ItemGroup>
     <Compile Remove="Platforms\**\*.*" />


### PR DESCRIPTION
If I check SupportMulticast and OperationalStatus on adapter at the second time execution, I get a crash on Android Nougat.

I wrote a issue called "Crash second time resolve execution on android nougat #90" on your library.

This is the error that I get on Nougat:
08-07 10:22:02.468 F/art     (32116): art/runtime/java_vm_ext.cc:470] JNI DETECTED ERROR IN APPLICATION: use of deleted local reference 0x200019
08-07 10:22:02.468 F/art     (32116): art/runtime/java_vm_ext.cc:470]     from void md5b60ffeb829f638581ab2bb9b1a7f4f3f.ButtonRenderer_ButtonClickListener.n_onClick(android.view.View)