### PR TITLE
Made the Zeroconf project a multi target project and add a net46 target

### DIFF
--- a/Zeroconf/Zeroconf.csproj
+++ b/Zeroconf/Zeroconf.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <Authors>Oren Novotny</Authors>
     <PackageLicenseUrl>http://opensource.org/licenses/ms-pl</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/onovotny/Zeroconf</PackageProjectUrl>


### PR DESCRIPTION
We need to target 4.6 exactly because this is what System.Reactive is targeting, if we target 4.6.1 or 4.6.2 we end up with a ton of additional runtime assemblies to the output dir