### PR TITLE
Bugfix - object disposal happening at inappropriate time

### DIFF
--- a/Zeroconf/NetworkInterface.cs
+++ b/Zeroconf/NetworkInterface.cs
@@ -159,7 +159,7 @@ namespace Zeroconf
                         Debug.WriteLine("Done Scanning");
 
 
-                        await recTask.ConfigureAwait(true);
+                        await recTask.ConfigureAwait(false);
                         
                         ((IDisposable)client).Dispose();
 

--- a/Zeroconf/NetworkInterface.cs
+++ b/Zeroconf/NetworkInterface.cs
@@ -160,8 +160,6 @@ namespace Zeroconf
 
 
                         await recTask.ConfigureAwait(false);
-                        
-                        ((IDisposable)client).Dispose();
 
                         return;
                     }

--- a/Zeroconf/NetworkInterface.cs
+++ b/Zeroconf/NetworkInterface.cs
@@ -156,12 +156,12 @@ namespace Zeroconf
 
                         Volatile.Write(ref shouldCancel, true);
 
-                        ((IDisposable)client).Dispose();
-
                         Debug.WriteLine("Done Scanning");
 
 
-                        await recTask.ConfigureAwait(false);
+                        await recTask.ConfigureAwait(true);
+                        
+                        ((IDisposable)client).Dispose();
 
                         return;
                     }


### PR DESCRIPTION
We were getting an exception a lot on iOS for the UDP client was disposed of before trying to access it inside recTask.

The NetworkInterface class has a call to dispose inside of a using statement, this is calling an issue primarily for iOS where the object is disposed immediately and before the object is done being used. 

Using statement is on line 83 of NetworkInterface.cs
` using (var client = new UdpClient())`

The call to Dispose, inside of the using statement, was on line 159
`((IDisposable)client).Dispose();`

The Using statement disposes of the object on its own, so there is no need to call Dispose early
Reference: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement

My apologies for the multiple commits, this is one of my first public contributions here on GitHub.