### PR TITLE
Add IPv6 address support to the response

### DIFF
--- a/Zeroconf/ZeroconfResolver.cs
+++ b/Zeroconf/ZeroconfResolver.cs
@@ -89,9 +89,7 @@ namespace Zeroconf
 
         static ZeroconfHost ResponseToZeroconf(Response response, string remoteAddress, ResolveOptions options)
         {
-            var z = new ZeroconfHost
-            {
-                IPAddresses = response.Answers
+            List<string> ipv4Adresses = response.Answers
                                       .Select(r => r.RECORD)
                                       .OfType<RecordA>()
                                       .Concat(response.Additionals
@@ -99,7 +97,21 @@ namespace Zeroconf
                                                       .OfType<RecordA>())
                                       .Select(aRecord => aRecord.Address)
                                       .Distinct()
-                                      .ToList()
+                                      .ToList();
+
+            List<string> ipv6Adresses = response.Answers
+                                      .Select(r => r.RECORD)
+                                      .OfType<RecordAAAA>()
+                                      .Concat(response.Additionals
+                                                      .Select(r => r.RECORD)
+                                                      .OfType<RecordAAAA>())
+                                      .Select(aRecord => aRecord.Address)
+                                      .Distinct()
+                                      .ToList();
+                                      
+            var z = new ZeroconfHost
+            {
+                IPAddresses = ipv4Adresses.Concat(ipv6Adresses).ToList()
             };
 
             z.Id = z.IPAddresses.FirstOrDefault() ?? remoteAddress;


### PR DESCRIPTION
Add IPv6 AAAA record addresses to the response when they are found in it. Should not change the first address tacked on the service, which should be an IPv4 address if one is found.

Rather new to the contribution thing and also to DNS-ServiceDiscovery, but this solves my problem of not having the IPv6 address of the device I found when it resolved.