### PR TITLE
Xamarin.iOS: Add workaround for new restrictions in iOS 14.5+

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,105 @@ You'll need to have the following permissions on your manifest depending on what
  - Private Networks (Client & Server)
  - Internet (Client & Server)
 
+## Xamarin.iOS on iOS 14.5+
+
+iOS 14.5 and later introduced new restrictions on mDNS clients. Low-level socket-based clients (like Zeroconf) are blocked at the iOS library/system call level
+unless the program has a special com.apple.developer.networking.multicast entitlement.
+
+If your app must browse arbitrary/unknown-at-compile-time services, you must obtain the com.apple.developer.networking.multicast entitlement from Apple.
+If you **do** obtain the entitlement, somewhere early in your app set the property ZeroconfResolver.UseBSDSocketsZeroconfOniOS to true; this will cause the Zeroconf
+library to behave as it always has and no workaround code will be executed.
+
+For all other apps that know which mDNS services they must interact with: one way to work around this restriction is to use the iOS NSNetServiceBrowser
+and NSNetService objects. A workaround using this method is now built in to Zeroconf; on iOS version 14.5 and greater, when ZeroconfResolver.ResolveAsync() or
+ZeroconfResolver.BrowseAsync() functions are called, this workaround code is executed.
+
+### Setup
+
+This following actions are required for this workaround:
+
+1. In your Xamarin.iOS project, modify Info.plist to include something like the following:
+
+```
+  <key>NSLocalNetworkUsageDescription</key>
+  <string>Looking for local mDNS/Bonjour services</string>
+  <key>NSBonjourServices</key>
+  <array>
+    <string>_audioplayer-discovery._tcp</string>
+    <string>_http._tcp</string>
+    <string>_printer._tcp</string>
+    <string>_apple-mobdev2._tcp</string>
+  </array>
+```
+
+The effect of the above: the first time your app runs, iOS will prompt the user for permission to allow mDNS queries from your app; it will display the
+<string> value of the key NSLocalNetworkUsageDescription to the user.
+
+For the key NSBonjourServices, its array of <string> values is the list of mDNS services that your app needs in order to run properly;
+iOS will only allow mDNS information from those listed services to reach your app. Note that the domain (usually ".local.") is not specified in Info.plist.
+
+Both the NSLocalNetworkUsageDescription and NSBonjourServices key values should be changed to what is required for your application.
+
+2. Possible modification of BrowseAsync() calling code, if applicable
+
+Calling BrowseAsync() followed by ResolveAsync() is essentially doing the same work twice: BrowseAsync is simulated using ResolveAsync() with the list of
+NSBonjourServices from Info.plist. When you can modify the code, calling only ResolveAsync() only will provide you all the information you need in half the time.
+
+The list of services from Info.plist are obtainable from ZeroconfResolver.GetiOSInfoPlistServices(), and a platform-independent way to know if the workaround
+is enabled is the property ZeroconfResolver.IsiOSWorkaroundEnabled.
+
+If you have to deal with custom mDNS domains, ZeroconfResolver.GetiOSDomains() will search the network for domains and return their names. The chosen domain
+may then be used as a parameter to ZeroconfResolver.GetiOSInfoPlistServices(domain). See
+[Apple's documentation](https://developer.apple.com/library/archive/documentation/Networking/Conceptual/NSNetServiceProgGuide/Articles/BrowsingForServices.html)
+
+Example browse and resolve code:
+
+```csharp
+IReadOnlyList<IZeroconfHost> responses = null;
+
+IReadOnlyList<string> domains;
+if (ZeroconfResolver.IsiOSWorkaroundEnabled)
+{
+    // Demonstrates how using ZeroconfResolver.GetiOSInfoPlistServices() is much faster than ZeroconfResolver.BrowseDomainsAsync()
+    //
+    // In real life, you'd only query the domains if you were planning on presenting the user with a choice of domains to browse,
+    //  or the app knows in advance there will be a choice and what the domain names would be
+    //
+    // This code assumes there will only be one domain returned ("local.") In general, if you don't have a requirement to handle domains,
+    //  just call GetiOSInfoPlistServices() with zero arguments
+
+    var iosDomains = await ZeroconfResolver.GetiOSDomains();
+    string selectedDomain = (iosDomains.Count > 0) ? iosDomains[0] : null;
+
+    domains = ZeroconfResolver.GetiOSInfoPlistServices(selectedDomain);
+}
+else
+{
+    var browseDomains = await ZeroconfResolver.BrowseDomainsAsync();
+    domains = browseDomains.Select(g => g.Key).ToList();
+}
+
+responses = await ZeroconfResolver.ResolveAsync(domains);
+```
+
+### Unimplemented features in the workaround
+
+ListenForAnnouncementsAsync()
+
+ResolverListener()
+
+### Implementation Details
+
+The callback functions are based on a simple-minded implementation: they will be called only after each ScanTime interval has expired for each distinct
+protocol/mDNS service.
+
+The more protocols/mDNS services you resolve, the longer it takes the library to return: minimumTotalDelayTime = (nServices * ScanTime).
+
+### Known bugs
+
+There is no propagation of errors (NetService_ResolveFailure, Browser_NotSearched) from the iOS API to ZeroconfSwitch. If any of these errors occur,
+you simply get nothing and like it.
+
 ## Credits
 
 This library was made possible through the efforts of the following projects:

--- a/Zeroconf/BonjourBrowser.cs
+++ b/Zeroconf/BonjourBrowser.cs
@@ -1,0 +1,489 @@
+﻿#if __IOS__
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Foundation;
+using UIKit;
+using Network;
+
+using ObjCRuntime;
+
+namespace Zeroconf
+{
+    class BonjourBrowser
+    {
+        NSNetServiceBrowser netServiceBrowser = new NSNetServiceBrowser();
+
+        Dictionary<string, NSNetService> discoveredServiceDict = new Dictionary<string, NSNetService>();
+        Dictionary<string, ZeroconfHost> zeroconfHostDict = new Dictionary<string, ZeroconfHost>();
+
+        ResolveOptions _resolveOptions;
+        Action<IZeroconfHost> _resolveCallback = null;
+        CancellationToken _resolveCancellationToken;
+        System.Net.NetworkInformation.NetworkInterface[] _resolveNetInterfacesToSendRequestOn;
+
+        const double netServiceResolveTimeout = 5D;
+
+        public BonjourBrowser()
+        {
+            netServiceBrowser.FoundDomain += Browser_FoundDomain;
+            netServiceBrowser.DomainRemoved += Browser_DomainRemoved;
+
+            netServiceBrowser.FoundService += Browser_FoundService;
+            netServiceBrowser.ServiceRemoved += Browser_ServiceRemoved;
+
+            netServiceBrowser.SearchStarted += Browser_SearchStarted;
+            netServiceBrowser.NotSearched += Browser_NotSearched;
+            netServiceBrowser.SearchStopped += Browser_SearchStopped;
+        }
+
+        public void SetResolveOptions(ResolveOptions resolveOptions,
+                                        Action<IZeroconfHost> callback = null,
+                                        CancellationToken cancellationToken = default(CancellationToken),
+                                        System.Net.NetworkInformation.NetworkInterface[] netInterfacesToSendRequestOn = null)
+        {
+            _resolveOptions = resolveOptions;
+            _resolveCallback = callback;
+            _resolveCancellationToken = cancellationToken;
+            _resolveNetInterfacesToSendRequestOn = netInterfacesToSendRequestOn;
+        }
+
+        private void Browser_FoundDomain(object sender, NSNetDomainEventArgs e)
+        {
+            Debug.WriteLine($"{nameof(Browser_FoundDomain)}: Domain {e.Domain} MoreComing {e.MoreComing.ToString()}");
+        }
+
+        private void Browser_DomainRemoved(object sender, NSNetDomainEventArgs e)
+        {
+            Debug.WriteLine($"{nameof(Browser_FoundDomain)}: Domain {e.Domain} MoreComing {e.MoreComing.ToString()}");
+        }
+
+        private void Browser_FoundService(object sender, NSNetServiceEventArgs e)
+        {
+            NSNetService netService = e.Service;
+
+            netService.AddressResolved += NetService_AddressResolved;
+            netService.Stopped += NetService_Stopped;
+            netService.ResolveFailure += NetService_ResolveFailure;
+
+            Debug.WriteLine($"{nameof(Browser_FoundService)}: Name {netService?.Name} Type {netService?.Type} Domain {netService?.Domain} " +
+                $"HostName {netService?.HostName} Port {netService?.Port} MoreComing {e.MoreComing.ToString()}");
+
+            if (netService != null)
+            {
+                Debug.WriteLine($"{nameof(Browser_FoundService)}: {nameof(netService)}.Resolve({netServiceResolveTimeout.ToString()})");
+                netService.Resolve(netServiceResolveTimeout);
+            }
+            else
+            {
+                Debug.WriteLine($"{nameof(Browser_FoundService)}: service is null");
+            }
+        }
+
+        private void NetService_AddressResolved(object sender, EventArgs e)
+        {
+            NSNetService netService = null;
+
+            if (sender is NSNetService)
+            {
+                netService = (NSNetService)sender;
+
+                Debug.WriteLine($"{nameof(NetService_AddressResolved)}: Name {netService?.Name} Type {netService?.Type} Domain {netService?.Domain} " +
+                    $"HostName {netService?.HostName} Port {netService?.Port} Addresses {GetZeroconfHostKey(netService)}");
+
+                if (netService.TxtRecordData != null)
+                {
+                    NSDictionary dict = NSNetService.DictionaryFromTxtRecord(netService.TxtRecordData);
+                    if (dict != null)
+                    {
+                        if (dict.Count > 0)
+                        {
+                            foreach (var key in dict.Keys)
+                            {
+                                Debug.WriteLine($"{nameof(Browser_FoundService)}: Key {key} Value {dict[key].ToString()}");
+                            }
+                        }
+                        else
+                        {
+                            Debug.WriteLine($"{nameof(Browser_FoundService)}: Service.DictionaryFromTxtRecord has 0 entries");
+                        }
+                    }
+                    else
+                    {
+                        Debug.WriteLine($"{nameof(Browser_FoundService)}: Service.DictionaryFromTxtRecord returned null");
+                    }
+                }
+                else
+                {
+                    Debug.WriteLine($"{nameof(Browser_FoundService)}: TxtRecordData is null");
+                }
+
+                string serviceKey = GetNsNetServiceKey(netService);
+                lock (discoveredServiceDict)
+                {
+                    discoveredServiceDict[serviceKey] = netService;
+                }
+            }
+        }
+
+        private void NetService_ResolveFailure(object sender, NSNetServiceErrorEventArgs e)
+        {
+            NSNetService netService = null;
+
+            if (sender is NSNetService)
+            {
+                netService = (NSNetService)sender;
+            }
+
+            Debug.WriteLine($"{nameof(NetService_ResolveFailure)}: Name {netService?.Name} Type {netService?.Type} Domain {netService?.Domain} " +
+                $"HostName {netService?.HostName} Port {netService?.Port}");
+
+            NSDictionary errors = e.Errors;
+
+            Debug.WriteLine($"{nameof(NetService_ResolveFailure)}: Errors {errors?.ToString()}");
+
+            if (errors != null)
+            {
+                if (errors.Count > 0)
+                {
+                    foreach (var key in errors.Keys)
+                    {
+                        Debug.WriteLine($"{nameof(NetService_ResolveFailure)}: Key {key} Value {errors[key].ToString()}");
+                    }
+                }
+                else
+                {
+                    Debug.WriteLine($"{nameof(NetService_ResolveFailure)}: errors has 0 entries");
+                }
+            }
+            else
+            {
+                Debug.WriteLine($"{nameof(NetService_ResolveFailure)}: errors is null");
+            }
+        }
+
+        private void NetService_Stopped(object sender, EventArgs e)
+        {
+            NSNetService netService = null;
+
+            if (sender is NSNetService)
+            {
+                netService = (NSNetService)sender;
+            }
+
+            Debug.WriteLine($"{nameof(NetService_Stopped)}: Name {netService?.Name} Type {netService?.Type} Domain {netService?.Domain} " +
+                $"HostName {netService?.HostName} Port {netService?.Port}");
+        }
+
+        private void Browser_ServiceRemoved(object sender, NSNetServiceEventArgs e)
+        {
+            NSNetService service = e.Service;
+
+            Debug.WriteLine($"{nameof(Browser_ServiceRemoved)}: Name {service.Name} Type {service.Type} Domain {service.Domain} " + 
+                $"HostName {service.HostName} Port {service.Port} MoreComing {e.MoreComing.ToString()}");
+
+            string serviceKey = GetNsNetServiceKey(service);
+            lock (discoveredServiceDict)
+            {
+                discoveredServiceDict.Remove(serviceKey);
+            }
+        }
+
+        private void Browser_SearchStarted(object sender, EventArgs e)
+        {
+            Debug.WriteLine($"{nameof(Browser_SearchStarted)}");
+        }
+
+        private void Browser_NotSearched(object sender, NSNetServiceErrorEventArgs e)
+        {
+            NSDictionary errors = e.Errors;
+
+            Debug.WriteLine($"{nameof(Browser_NotSearched)}: Errors {errors?.ToString()}");
+
+            if (errors != null)
+            {
+                if (errors.Count > 0)
+                {
+                    foreach (var key in errors.Keys)
+                    {
+                        Debug.WriteLine($"{nameof(Browser_NotSearched)}: Key {key} Value {errors[key].ToString()}");
+                    }
+                }
+                else
+                {
+                    Debug.WriteLine($"{nameof(Browser_NotSearched)}: errors has 0 entries");
+                }
+            }
+            else
+            {
+                Debug.WriteLine($"{nameof(Browser_NotSearched)}: errors is null");
+            }
+        }
+
+        private void Browser_SearchStopped(object sender, EventArgs e)
+        {
+            Debug.WriteLine($"{nameof(Browser_SearchStopped)}");
+        }
+
+        //
+        // Start/Stop search NSNetService search
+        //
+
+        public void StartServiceSearch()
+        {
+            const string localDomainForParse = ".local.";
+            const string localDomain = "local.";
+            int localDomainLength = localDomain.Length;
+
+            // All previous service discovery results are discarded
+
+            lock (discoveredServiceDict)
+            {
+                discoveredServiceDict.Clear();
+            }
+
+            lock (zeroconfHostDict)
+            {
+                zeroconfHostDict.Clear();
+            }
+
+            foreach (var protocol in _resolveOptions.Protocols)
+            {
+                string serviceType = string.Empty;
+                string domain = string.Empty;
+
+                if (protocol.ToLower().EndsWith(localDomainForParse))
+                {
+                    serviceType = protocol.Substring(0, protocol.Length - localDomainLength);
+                    domain = protocol.Substring(serviceType.Length);
+                }
+                else
+                {
+                    serviceType = BonjourBrowser.GetServiceType(protocol);
+                    if (serviceType != null)
+                    {
+                        if (protocol.Length > serviceType.Length)
+                        {
+                            domain = protocol.Substring(serviceType.Length);
+
+                            //           6 = delim.Length
+                            //          /----\ 
+                            // _foo._bar._tcp. example.com.
+                            // 012345678901234 567890123456 index = [0, 26]
+                            // 123456789012345 678901234567 length = 27
+                            //   serviceType      domain
+                        }
+                        else
+                        {
+                            domain = string.Empty;
+                        }
+                    }
+                    else
+                    {
+                        serviceType = protocol;
+                        domain = string.Empty;
+                    }
+                }
+
+                Debug.WriteLine($"{nameof(StartServiceSearch)}: {nameof(netServiceBrowser)}.SearchForServices(Type {serviceType} Domain {domain})");
+
+                netServiceBrowser.SearchForServices(serviceType, domain);
+            }
+        }
+
+        public void StopServiceSearch()
+        {
+            Debug.WriteLine($"{nameof(StopServiceSearch)}: {nameof(netServiceBrowser)}.Stop()");
+            netServiceBrowser.Stop();
+        }
+
+        public static string GetServiceType(string protocol, bool includeTcpUdpDelimiter = true)
+        {
+            string serviceType = null;
+            string[] delimArray = { "._tcp.", "._udp." };
+
+            foreach (string delim in delimArray)
+            {
+                if (protocol.Contains(delim))
+                {
+                    if (includeTcpUdpDelimiter)
+                    {
+                        serviceType = protocol.Substring(0, protocol.IndexOf(delim) + delim.Length);
+                    }
+                    else
+                    {
+                        serviceType = protocol.Substring(0, protocol.IndexOf(delim));
+                    }
+                    break;
+                }
+            }
+
+            return serviceType;
+        }
+
+        //
+        // ZeroconfHost results
+        //
+
+        public IReadOnlyList<IZeroconfHost> ReturnZeroconfHostResults()
+        {
+            Debug.WriteLine($"{nameof(ReturnZeroconfHostResults)}");
+
+            lock (zeroconfHostDict)
+            {
+                zeroconfHostDict.Clear();
+            }
+
+            RefreshZeroconfHostDict();
+
+            List<IZeroconfHost> hostList = new List<IZeroconfHost>();
+
+            lock (zeroconfHostDict)
+            {
+                hostList.AddRange(zeroconfHostDict.Values);
+            }
+
+            Debug.WriteLine($"{nameof(ReturnZeroconfHostResults)}: Returning hostList.Count {hostList.Count}");
+
+            return hostList;
+        }
+
+        void RefreshZeroconfHostDict()
+        {
+            // Do not walk discoveredServiceDict[] directly
+            // If a NSNetService is in discoveredServiceDict[], it was resolved successfully before it was added
+
+            List<NSNetService> nsNetServiceList = new List<NSNetService>();
+            lock (discoveredServiceDict)
+            {
+                nsNetServiceList.AddRange(discoveredServiceDict.Values);
+            }
+
+            // For each NSNetService, create a ZeroconfHost record
+
+            foreach (var nsNetService in nsNetServiceList)
+            {
+                Debug.WriteLine($"{nameof(ReturnZeroconfHostResults)}: Name {nsNetService.Name} Type {nsNetService.Type} Domain {nsNetService.Domain} " +
+                    $"HostName {nsNetService.HostName} Port {nsNetService.Port}");
+
+                // Obtain or create ZeroconfHost
+
+                ZeroconfHost host = GetOrCreateZeroconfHost(nsNetService);
+
+                // Add service to ZeroconfHost record
+
+                Service svc = new Service();
+                svc.Name = GetNsNetServiceName(nsNetService);
+                svc.Port = (int)nsNetService.Port;
+                // svc.Ttl = is not available
+
+                NSData txtRecordData = nsNetService.GetTxtRecordData();
+                if (txtRecordData != null)
+                {
+                    NSDictionary txtDict = NSNetService.DictionaryFromTxtRecord(txtRecordData);
+                    if (txtDict != null)
+                    {
+                        if (txtDict.Count > 0)
+                        {
+                            foreach (var key in txtDict.Keys)
+                            {
+                                Debug.WriteLine($"{nameof(ReturnZeroconfHostResults)}: Key {key} Value {txtDict[key].ToString()}");
+                            }
+
+                            Dictionary<string, string> propertyDict = new Dictionary<string, string>();
+
+                            foreach (var key in txtDict.Keys)
+                            {
+                                propertyDict[key.ToString()] = txtDict[key].ToString();
+                            }
+                            svc.AddPropertySet(propertyDict);
+                        }
+                        else
+                        {
+                            Debug.WriteLine($"{nameof(ReturnZeroconfHostResults)}: Service.DictionaryFromTxtRecord has 0 entries");
+                        }
+                    }
+                    else
+                    {
+                        Debug.WriteLine($"{nameof(ReturnZeroconfHostResults)}: Service.DictionaryFromTxtRecord returned null");
+                    }
+                }
+
+                host.AddService(svc);
+            }
+        }
+
+        ZeroconfHost GetOrCreateZeroconfHost(NSNetService service)
+        {
+            ZeroconfHost host;
+            string hostKey = GetZeroconfHostKey(service);
+
+            lock (zeroconfHostDict)
+            {
+                if (!zeroconfHostDict.TryGetValue(hostKey, out host))
+                {
+                    host = new ZeroconfHost();
+                    host.DisplayName = service.Name;
+
+                    List<string> ipAddrList = new List<string>();
+                    foreach (NSData address in service.Addresses)
+                    {
+                        Sockaddr saddr = Sockaddr.CreateSockaddr(address.Bytes);
+                        IPAddress ipAddr = Sockaddr.CreateIPAddress(saddr);
+                        if (ipAddr != null)
+                        {
+                            ipAddrList.Add(ipAddr.ToString());
+                        }
+                    }
+                    host.IPAddresses = ipAddrList;
+
+                    host.Id = host.IPAddress;
+
+                    zeroconfHostDict[hostKey] = host;
+                }
+            }
+
+            return host;
+        }
+
+        //
+        // NsNetService utils
+        //
+
+        string GetNsNetServiceKey(NSNetService service)
+        {
+            string hostKey = GetZeroconfHostKey(service);
+            return $"{hostKey}:{service.Type}{service.Domain}";
+        }
+
+        string GetNsNetServiceName(NSNetService service)
+        {
+            return $"{service.Type}{service.Domain}";
+        }
+
+        string GetZeroconfHostKey(NSNetService service)
+        {
+            StringBuilder sb = new StringBuilder();
+
+            foreach (NSData address in service.Addresses)
+            {
+                Sockaddr saddr = Sockaddr.CreateSockaddr(address.Bytes);
+                IPAddress ipAddr = Sockaddr.CreateIPAddress(saddr);
+                if (ipAddr != null)
+                {
+                    sb.Append((sb.Length == 0 ? ipAddr.ToString() : $";{ipAddr.ToString()}"));
+                }
+            }
+
+            return sb.ToString();
+        }
+    }
+}
+#endif

--- a/Zeroconf/BonjourBrowser.cs
+++ b/Zeroconf/BonjourBrowser.cs
@@ -10,10 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Foundation;
-using UIKit;
-using Network;
-
-using ObjCRuntime;
+using CoreFoundation;
 
 namespace Zeroconf
 {
@@ -23,15 +20,15 @@ namespace Zeroconf
 
         Dictionary<string, NSNetService> discoveredServiceDict = new Dictionary<string, NSNetService>();
         Dictionary<string, ZeroconfHost> zeroconfHostDict = new Dictionary<string, ZeroconfHost>();
+        HashSet<string> domainHash = new HashSet<string>();
 
-        ResolveOptions _resolveOptions;
-        Action<IZeroconfHost> _resolveCallback = null;
-        CancellationToken _resolveCancellationToken;
-        System.Net.NetworkInformation.NetworkInterface[] _resolveNetInterfacesToSendRequestOn;
+        double netServiceResolveTimeout;
 
-        const double netServiceResolveTimeout = 5D;
-
-        public BonjourBrowser()
+        /// <summary>
+        /// Implements iOS mDNS browse and resolve
+        /// </summary>
+        /// <param name="resolveTimeout">Time limit for NSNetService.Resolve() operation</param>
+        public BonjourBrowser(TimeSpan resolveTimeout = default(TimeSpan))
         {
             netServiceBrowser.FoundDomain += Browser_FoundDomain;
             netServiceBrowser.DomainRemoved += Browser_DomainRemoved;
@@ -42,27 +39,26 @@ namespace Zeroconf
             netServiceBrowser.SearchStarted += Browser_SearchStarted;
             netServiceBrowser.NotSearched += Browser_NotSearched;
             netServiceBrowser.SearchStopped += Browser_SearchStopped;
-        }
 
-        public void SetResolveOptions(ResolveOptions resolveOptions,
-                                        Action<IZeroconfHost> callback = null,
-                                        CancellationToken cancellationToken = default(CancellationToken),
-                                        System.Net.NetworkInformation.NetworkInterface[] netInterfacesToSendRequestOn = null)
-        {
-            _resolveOptions = resolveOptions;
-            _resolveCallback = callback;
-            _resolveCancellationToken = cancellationToken;
-            _resolveNetInterfacesToSendRequestOn = netInterfacesToSendRequestOn;
+            netServiceResolveTimeout = (resolveTimeout != default(TimeSpan)) ? resolveTimeout.TotalSeconds : 5D;
         }
 
         private void Browser_FoundDomain(object sender, NSNetDomainEventArgs e)
         {
             Debug.WriteLine($"{nameof(Browser_FoundDomain)}: Domain {e.Domain} MoreComing {e.MoreComing.ToString()}");
+            lock (domainHash)
+            {
+                domainHash.Add(e.Domain);
+            }
         }
 
         private void Browser_DomainRemoved(object sender, NSNetDomainEventArgs e)
         {
             Debug.WriteLine($"{nameof(Browser_FoundDomain)}: Domain {e.Domain} MoreComing {e.MoreComing.ToString()}");
+            lock (domainHash)
+            {
+                domainHash.Remove(e.Domain);
+            }
         }
 
         private void Browser_FoundService(object sender, NSNetServiceEventArgs e)
@@ -89,9 +85,7 @@ namespace Zeroconf
 
         private void NetService_AddressResolved(object sender, EventArgs e)
         {
-            NSNetService netService = null;
-
-            if (sender is NSNetService)
+            if (sender is NSNetService netService)
             {
                 netService = (NSNetService)sender;
 
@@ -135,51 +129,47 @@ namespace Zeroconf
 
         private void NetService_ResolveFailure(object sender, NSNetServiceErrorEventArgs e)
         {
-            NSNetService netService = null;
-
-            if (sender is NSNetService)
+            if (sender is NSNetService netService)
             {
                 netService = (NSNetService)sender;
-            }
 
-            Debug.WriteLine($"{nameof(NetService_ResolveFailure)}: Name {netService?.Name} Type {netService?.Type} Domain {netService?.Domain} " +
-                $"HostName {netService?.HostName} Port {netService?.Port}");
+                Debug.WriteLine($"{nameof(NetService_ResolveFailure)}: Name {netService?.Name} Type {netService?.Type} Domain {netService?.Domain} " +
+                    $"HostName {netService?.HostName} Port {netService?.Port}");
 
-            NSDictionary errors = e.Errors;
+                NSDictionary errors = e.Errors;
 
-            Debug.WriteLine($"{nameof(NetService_ResolveFailure)}: Errors {errors?.ToString()}");
+                Debug.WriteLine($"{nameof(NetService_ResolveFailure)}: Errors {errors?.ToString()}");
 
-            if (errors != null)
-            {
-                if (errors.Count > 0)
+                if (errors != null)
                 {
-                    foreach (var key in errors.Keys)
+                    if (errors.Count > 0)
                     {
-                        Debug.WriteLine($"{nameof(NetService_ResolveFailure)}: Key {key} Value {errors[key].ToString()}");
+                        foreach (var key in errors.Keys)
+                        {
+                            Debug.WriteLine($"{nameof(NetService_ResolveFailure)}: Key {key} Value {errors[key].ToString()}");
+                        }
+                    }
+                    else
+                    {
+                        Debug.WriteLine($"{nameof(NetService_ResolveFailure)}: errors has 0 entries");
                     }
                 }
                 else
                 {
-                    Debug.WriteLine($"{nameof(NetService_ResolveFailure)}: errors has 0 entries");
+                    Debug.WriteLine($"{nameof(NetService_ResolveFailure)}: errors is null");
                 }
-            }
-            else
-            {
-                Debug.WriteLine($"{nameof(NetService_ResolveFailure)}: errors is null");
             }
         }
 
         private void NetService_Stopped(object sender, EventArgs e)
         {
-            NSNetService netService = null;
-
-            if (sender is NSNetService)
+            if (sender is NSNetService netService)
             {
                 netService = (NSNetService)sender;
-            }
 
-            Debug.WriteLine($"{nameof(NetService_Stopped)}: Name {netService?.Name} Type {netService?.Type} Domain {netService?.Domain} " +
-                $"HostName {netService?.HostName} Port {netService?.Port}");
+                Debug.WriteLine($"{nameof(NetService_Stopped)}: Name {netService?.Name} Type {netService?.Type} Domain {netService?.Domain} " +
+                    $"HostName {netService?.HostName} Port {netService?.Port}");
+            }
         }
 
         private void Browser_ServiceRemoved(object sender, NSNetServiceEventArgs e)
@@ -236,7 +226,37 @@ namespace Zeroconf
         // Start/Stop search NSNetService search
         //
 
-        public void StartServiceSearch()
+        public void StartDomainSearch()
+        {
+            Debug.WriteLine($"{nameof(StartDomainSearch)}: {nameof(netServiceBrowser)}.SearchForBrowsableDomains()");
+
+            lock (domainHash)
+            {
+                domainHash.Clear();
+            }
+
+            netServiceBrowser.SearchForBrowsableDomains();
+        }
+
+        public void StopDomainSearch()
+        {
+            Debug.WriteLine($"{nameof(StopDomainSearch)}: {nameof(netServiceBrowser)}.Stop()");
+            netServiceBrowser.Stop();
+        }
+
+        public List<string> GetFoundDomainList()
+        {
+            List<string> results = new List<string>();
+
+            lock (domainHash)
+            {
+                results.AddRange(domainHash.ToList());
+            }
+
+            return results;
+        }
+
+        public void StartServiceSearch(string protocol)
         {
             const string localDomainForParse = ".local.";
             const string localDomain = "local.";
@@ -254,48 +274,45 @@ namespace Zeroconf
                 zeroconfHostDict.Clear();
             }
 
-            foreach (var protocol in _resolveOptions.Protocols)
+            string serviceType = string.Empty;
+            string domain = string.Empty;
+
+            if (protocol.ToLower().EndsWith(localDomainForParse))
             {
-                string serviceType = string.Empty;
-                string domain = string.Empty;
-
-                if (protocol.ToLower().EndsWith(localDomainForParse))
+                serviceType = protocol.Substring(0, protocol.Length - localDomainLength);
+                domain = protocol.Substring(serviceType.Length);
+            }
+            else
+            {
+                serviceType = BonjourBrowser.GetServiceType(protocol);
+                if (serviceType != null)
                 {
-                    serviceType = protocol.Substring(0, protocol.Length - localDomainLength);
-                    domain = protocol.Substring(serviceType.Length);
-                }
-                else
-                {
-                    serviceType = BonjourBrowser.GetServiceType(protocol);
-                    if (serviceType != null)
+                    if (protocol.Length > serviceType.Length)
                     {
-                        if (protocol.Length > serviceType.Length)
-                        {
-                            domain = protocol.Substring(serviceType.Length);
+                        domain = protocol.Substring(serviceType.Length);
 
-                            //           6 = delim.Length
-                            //          /----\ 
-                            // _foo._bar._tcp. example.com.
-                            // 012345678901234 567890123456 index = [0, 26]
-                            // 123456789012345 678901234567 length = 27
-                            //   serviceType      domain
-                        }
-                        else
-                        {
-                            domain = string.Empty;
-                        }
+                        //           6 = delim.Length
+                        //          /----\ 
+                        // _foo._bar._tcp. example.com.
+                        // 012345678901234 567890123456 index = [0, 26]
+                        // 123456789012345 678901234567 length = 27
+                        //   serviceType      domain
                     }
                     else
                     {
-                        serviceType = protocol;
                         domain = string.Empty;
                     }
                 }
-
-                Debug.WriteLine($"{nameof(StartServiceSearch)}: {nameof(netServiceBrowser)}.SearchForServices(Type {serviceType} Domain {domain})");
-
-                netServiceBrowser.SearchForServices(serviceType, domain);
+                else
+                {
+                    serviceType = protocol;
+                    domain = string.Empty;
+                }
             }
+
+            Debug.WriteLine($"{nameof(StartServiceSearch)}: {nameof(netServiceBrowser)}.SearchForServices(Type {serviceType} Domain {domain})");
+
+            netServiceBrowser.SearchForServices(serviceType, domain);
         }
 
         public void StopServiceSearch()
@@ -472,17 +489,69 @@ namespace Zeroconf
         {
             StringBuilder sb = new StringBuilder();
 
-            foreach (NSData address in service.Addresses)
+            if (service.Addresses != null)
             {
-                Sockaddr saddr = Sockaddr.CreateSockaddr(address.Bytes);
-                IPAddress ipAddr = Sockaddr.CreateIPAddress(saddr);
-                if (ipAddr != null)
+                foreach (NSData address in service.Addresses)
                 {
-                    sb.Append((sb.Length == 0 ? ipAddr.ToString() : $";{ipAddr.ToString()}"));
+                    if (address != null)
+                    {
+                        Sockaddr saddr = Sockaddr.CreateSockaddr(address.Bytes);
+                        IPAddress ipAddr = Sockaddr.CreateIPAddress(saddr);
+                        if (ipAddr != null)
+                        {
+                            sb.Append((sb.Length == 0 ? ipAddr.ToString() : $";{ipAddr.ToString()}"));
+                        }
+                    }
+                    else
+                    {
+                        Console.WriteLine($"{nameof(GetZeroconfHostKey)}: Got null entry in NSNetService.Addresses, Service {service?.Name}");
+                    }
                 }
+            }
+            else
+            {
+                Console.WriteLine($"{nameof(GetZeroconfHostKey)}: NSNetService.Addresses is null, Service {service?.Name}");
             }
 
             return sb.ToString();
+        }
+
+        public static List<string> GetNSBonjourServices(string domain = null)
+        {
+            List<string> browseServiceList = new List<string>();
+
+            var bundle = CFBundle.GetMain();
+            var infoPlistNsDict = bundle?.InfoDictionary;
+
+            const string infoPlistKey = "NSBonjourServices";
+            var nsBonjourServices = infoPlistNsDict?[infoPlistKey];
+            if (nsBonjourServices != null)
+            {
+                Console.WriteLine($"Found Info.plist key {infoPlistKey}");
+
+                if (nsBonjourServices is NSArray)
+                {
+                    var nsBonjourServiceArr = NSArray.ArrayFromHandle<NSString>(nsBonjourServices.Handle);
+                    foreach (var serviceItem in nsBonjourServiceArr)
+                    {
+                        var serviceItemStr = serviceItem.ToString();
+                        var browseService = (domain != null) ? $"{serviceItemStr}.{domain}" : serviceItemStr;
+
+                        Console.WriteLine($"  {infoPlistKey} PlistItem={serviceItemStr} BrowseService={browseService}");
+                        browseServiceList.Add(browseService);
+                    }
+                }
+                else
+                {
+                    throw new Exception($"Info.plist contains {infoPlistKey} but the value is not an array");
+                }
+            }
+            else
+            {
+                throw new ArgumentNullException($"Info.plist does not contain {infoPlistKey} array");
+            }
+
+            return browseServiceList;
         }
     }
 }

--- a/Zeroconf/Sockaddr.cs
+++ b/Zeroconf/Sockaddr.cs
@@ -1,0 +1,67 @@
+﻿#if __IOS__
+using Foundation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using UIKit;
+
+namespace Zeroconf
+{
+	public enum SockAddrFamily
+	{
+		Inet = 2,
+		Inet6 = 23
+	}
+
+	[StructLayout(LayoutKind.Explicit, Size = 28)]
+	public struct Sockaddr
+	{
+		[FieldOffset(0)] public byte sin_len;
+		[FieldOffset(1)] public byte sin_family;
+		[FieldOffset(2)] public short sin_port;
+		[FieldOffset(4)] public int sin_addr;
+
+		// IPv6
+		[FieldOffset(4)] public uint sin6_flowinfo;
+		[FieldOffset(8)] [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)] public byte[] sin6_addr8;
+		[FieldOffset(24)] public uint sin6_scope_id;
+
+		public static Sockaddr CreateSockaddr(IntPtr bytes)
+        {
+			Sockaddr sock = (Sockaddr)Marshal.PtrToStructure(bytes, typeof(Sockaddr));
+			return sock;
+		}
+
+		public static IPAddress CreateIPAddress(Sockaddr addr)
+        {
+			byte[] bytes = null;
+
+			switch (addr.sin_family)
+            {
+				case (byte)SockAddrFamily.Inet:
+					byte[] ipv4addr = new byte[4];
+					ipv4addr[0] = (byte)(addr.sin_addr & 0x000000FF);
+					ipv4addr[1] = (byte)((addr.sin_addr & 0x0000FF00) >> 8);
+					ipv4addr[2] = (byte)((addr.sin_addr & 0x00FF0000) >> 16);
+					ipv4addr[3] = (byte)((addr.sin_addr & 0xFF000000) >> 24);
+					bytes = ipv4addr;
+					break;
+				case (byte)SockAddrFamily.Inet6:
+					bytes = addr.sin6_addr8;
+					break;
+				default:
+#if false
+                    Console.WriteLine($"Unknown socket address family {addr.sin_family}");
+#endif
+                    bytes = null;
+                    break;
+            }
+
+			return (bytes != null) ? new IPAddress(bytes): null;
+        }
+    }
+}
+#endif

--- a/Zeroconf/Zeroconf.csproj
+++ b/Zeroconf/Zeroconf.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net46;xamarinios10</TargetFrameworks>
     <Authors>Claire Novotny</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/novotnyllc/Zeroconf</PackageProjectUrl>

--- a/Zeroconf/ZeroconfNetServiceBrowser.cs
+++ b/Zeroconf/ZeroconfNetServiceBrowser.cs
@@ -1,0 +1,111 @@
+#if __IOS__
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Zeroconf
+{
+    static class ZeroconfNetServiceBrowser
+    {
+        static internal async Task<IReadOnlyList<IZeroconfHost>> ResolveAsync(ResolveOptions options,
+                                                            Action<IZeroconfHost> callback = null,
+                                                            CancellationToken cancellationToken = default(CancellationToken),
+                                                            System.Net.NetworkInformation.NetworkInterface[] netInterfacesToSendRequestOn = null)
+        {
+            if (options == null) throw new ArgumentNullException(nameof(options));
+            if (netInterfacesToSendRequestOn != null)
+            {
+                throw new NotImplementedException($"iOS NSNetServiceBrowser/NSNetService does not support per-network interface requests");
+            }
+
+            List<IZeroconfHost> combinedResultList = new List<IZeroconfHost>();
+
+            // Seems you must reuse the one BonjourBrowser (which is really an NSNetServiceBrowser)... multiple instances do not play well together
+
+            BonjourBrowser bonjourBrowser = new BonjourBrowser();
+
+            foreach (var protocol in options.Protocols)
+            {
+                ResolveOptions perProtocolBrowseOption = new ResolveOptions(protocol)
+                {
+                    AllowOverlappedQueries = options.AllowOverlappedQueries,
+                    Retries = options.Retries,
+                    RetryDelay = options.RetryDelay,
+                    ScanQueryType = options.ScanQueryType,
+                    ScanTime = options.ScanTime,
+                };
+                bonjourBrowser.SetResolveOptions(perProtocolBrowseOption, callback, cancellationToken, netInterfacesToSendRequestOn);
+
+                bonjourBrowser.StartServiceSearch();
+
+                await Task.Delay(options.ScanTime, cancellationToken).ConfigureAwait(false);
+
+                bonjourBrowser.StopServiceSearch();
+
+                // Simpleminded callback implementation
+                var results = bonjourBrowser.ReturnZeroconfHostResults();
+                foreach (var result in results)
+                {
+                    if (callback != null)
+                    {
+                        callback(result);
+                    }
+                }
+
+                combinedResultList.AddRange(results);
+            }
+
+            return combinedResultList;
+        }
+
+        static internal async Task<ILookup<string, string>> BrowseDomainsAsync(List<string> browseDomainProtocolList, BrowseDomainsOptions options,
+                                                                     Action<string, string> callback = null,
+                                                                     CancellationToken cancellationToken = default(CancellationToken),
+                                                                     System.Net.NetworkInformation.NetworkInterface[] netInterfacesToSendRequestOn = null)
+        {
+            if (options == null) throw new ArgumentNullException(nameof(options));
+            if (netInterfacesToSendRequestOn != null)
+            {
+                throw new NotImplementedException($"iOS NSNetServiceBrowser/NSNetService does not support per-network interface requests");
+            }
+
+            ResolveOptions resolveOptions = new ResolveOptions(browseDomainProtocolList);
+            var zeroconfResults = await ResolveAsync(resolveOptions, callback: null, cancellationToken, netInterfacesToSendRequestOn);
+
+            List<IntermediateResult> resultsList = new List<IntermediateResult>();
+            foreach (var host in zeroconfResults)
+            {
+                foreach (var service in host.Services)
+                {
+                    foreach (var ipAddr in host.IPAddresses)
+                    {
+                        IntermediateResult b = new IntermediateResult();
+                        b.ServiceNameAndDomain = service.Key;
+                        b.HostIPAndService = $"{ipAddr}: {BonjourBrowser.GetServiceType(service.Value.Name, includeTcpUdpDelimiter: false)}";
+
+                        resultsList.Add(b);
+
+                        // Simpleminded callback implementation
+                        if (callback != null)
+                        {
+                            callback(service.Key, ipAddr);
+                        }
+                    }
+                }
+            }
+
+            ILookup<string, string> results = resultsList.ToLookup(k => k.ServiceNameAndDomain, h => h.HostIPAndService);
+            return results;
+        }
+
+        class IntermediateResult
+        {
+            public string ServiceNameAndDomain;
+            public string HostIPAndService;
+        }
+    }
+}
+#endif

--- a/Zeroconf/ZeroconfResolver.Async.cs
+++ b/Zeroconf/ZeroconfResolver.Async.cs
@@ -6,6 +6,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using Heijden.DNS;
 
+#if __IOS__
+using UIKit;
+#endif
+
 namespace Zeroconf
 {
     static partial class ZeroconfResolver
@@ -87,6 +91,7 @@ namespace Zeroconf
                                                                             System.Net.NetworkInformation.NetworkInterface[] netInterfacesToSendRequestOn = null)
         {
             if (options == null) throw new ArgumentNullException(nameof(options));
+#if !__IOS__
             Action<string, Response> wrappedAction = null;
             
             if (callback != null)
@@ -110,6 +115,61 @@ namespace Zeroconf
             return dict.Select(pair => ResponseToZeroconf(pair.Value, pair.Key, options))
                        .Where(zh => zh.Services.Any(s => options.Protocols.Contains(s.Key))) // Ensure we only return records that have matching services
                        .ToList();
+#else
+            if (UIDevice.CurrentDevice.CheckSystemVersion(14, 5))
+            {
+                return await ZeroconfNetServiceBrowser.ResolveAsync(options, callback, cancellationToken, netInterfacesToSendRequestOn);
+            }
+            else
+            {
+                Action<string, Response> wrappedAction = null;
+
+                if (callback != null)
+                {
+                    wrappedAction = (address, resp) =>
+                    {
+                        var zc = ResponseToZeroconf(resp, address, options);
+                        if (zc.Services.Any(s => options.Protocols.Contains(s.Key)))
+                        {
+                            callback(zc);
+                        }
+                    };
+                }
+
+                var dict = await ResolveInternal(options,
+                                                 wrappedAction,
+                                                 cancellationToken,
+                                                 netInterfacesToSendRequestOn)
+                                     .ConfigureAwait(false);
+
+                return dict.Select(pair => ResponseToZeroconf(pair.Value, pair.Key, options))
+                           .Where(zh => zh.Services.Any(s => options.Protocols.Contains(s.Key))) // Ensure we only return records that have matching services
+                           .ToList();
+            }
+#endif
+        }
+
+        // Should be set to the list of allowed protocols from info.plist; entries must include domain including terminating dot (usually ".local.")
+        // Used by BrowseDomainAsync only; the hack is that "browsing" is really just ResolveAsync() with the result formatted differently
+        static List<string> browseDomainProtocolList = new List<string>();
+
+        /// <summary>
+        ///     Sets browse domain protocols (provided using pattern "[protocol].[domain].") for Xamarin iOS 14.5+ integration
+        /// </summary>
+        /// <param name="protocols">IEnumerable of string browse domain protocols</param>
+        /// <returns></returns>
+        public static void SetBrowseDomainProtocols(IEnumerable<string> protocols)
+        {
+            if (protocols == null) { throw new ArgumentException(nameof(protocols)); }
+            browseDomainProtocolList.Clear();
+
+            foreach (var protocol in protocols)
+            {
+                if (protocol != null)
+                {
+                    browseDomainProtocolList.Add(protocol);
+                }
+            }
         }
 
         /// <summary>
@@ -160,6 +220,7 @@ namespace Zeroconf
         {
             if (options == null) throw new ArgumentNullException(nameof(options));
        
+#if !__IOS__
             Action<string, Response> wrappedAction = null;
             if (callback != null)
             {
@@ -183,6 +244,38 @@ namespace Zeroconf
                     select new { Service = service, Address = kvp.Key };
 
             return r.ToLookup(k => k.Service, k => k.Address);
+#else
+            if (UIDevice.CurrentDevice.CheckSystemVersion(14, 5))
+            {
+                return await ZeroconfNetServiceBrowser.BrowseDomainsAsync(browseDomainProtocolList, options, callback, cancellationToken, netInterfacesToSendRequestOn);
+            }
+            else
+            {
+                Action<string, Response> wrappedAction = null;
+                if (callback != null)
+                {
+                    wrappedAction = (address, response) =>
+                    {
+                        foreach (var service in BrowseResponseParser(response))
+                        {
+                            callback(service, address);
+                        }
+                    };
+                }
+
+                var dict = await ResolveInternal(options,
+                                                 wrappedAction,
+                                                 cancellationToken,
+                                                 netInterfacesToSendRequestOn)
+                                     .ConfigureAwait(false);
+
+                var r = from kvp in dict
+                        from service in BrowseResponseParser(kvp.Value)
+                        select new { Service = service, Address = kvp.Key };
+
+                return r.ToLookup(k => k.Service, k => k.Address);
+            }
+#endif
         }
 
         /// <summary>

--- a/ZeroconfTest.Xamarin/ZeroconfTest.Xamarin.iOS/Info.plist
+++ b/ZeroconfTest.Xamarin/ZeroconfTest.Xamarin.iOS/Info.plist
@@ -20,6 +20,15 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+  <key>NSLocalNetworkUsageDescription</key>
+  <string>Looking for local mDNS/Bonjour services</string>
+  <key>NSBonjourServices</key>
+  <array>
+    <string>_audioplayer-discovery._tcp</string>
+    <string>_http._tcp</string>
+    <string>_printer._tcp</string>
+    <string>_apple-mobdev2._tcp</string>
+  </array>
 	<key>MinimumOSVersion</key>
 	<string>10.0</string>
 	<key>CFBundleDisplayName</key>

--- a/ZeroconfTest.Xamarin/ZeroconfTest.Xamarin.iOS/ZeroconfTest.Xam.iOS.csproj
+++ b/ZeroconfTest.Xamarin/ZeroconfTest.Xamarin.iOS/ZeroconfTest.Xam.iOS.csproj
@@ -68,7 +68,7 @@
     <MtouchProfiling>False</MtouchProfiling>
     <MtouchFastDev>False</MtouchFastDev>
     <MtouchEnableGenericValueTypeSharing>True</MtouchEnableGenericValueTypeSharing>
-    <MtouchArch>ARMv7</MtouchArch>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
     <MtouchUseLlvm>False</MtouchUseLlvm>
     <MtouchUseThumb>False</MtouchUseThumb>
     <MtouchUseSGen>False</MtouchUseSGen>

--- a/ZeroconfTest.Xamarin/ZeroconfTest.Xamarin.iOS/ZeroconfTest.Xam.iOS.csproj
+++ b/ZeroconfTest.Xamarin/ZeroconfTest.Xamarin.iOS/ZeroconfTest.Xam.iOS.csproj
@@ -99,7 +99,7 @@
     <MtouchExtraArgs />
     <MtouchFastDev>False</MtouchFastDev>
     <MtouchEnableGenericValueTypeSharing>True</MtouchEnableGenericValueTypeSharing>
-    <MtouchArch>Default, ARMv7</MtouchArch>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
     <MtouchUseLlvm>False</MtouchUseLlvm>
     <MtouchUseThumb>False</MtouchUseThumb>
     <MtouchUseSGen>False</MtouchUseSGen>

--- a/ZeroconfTest.Xamarin/ZeroconfTest.Xamarin/App.cs
+++ b/ZeroconfTest.Xamarin/ZeroconfTest.Xamarin/App.cs
@@ -47,6 +47,16 @@ namespace ZeroconfTest.Xam
             };
         }
 
+        // See ZeroconfResolver.Async.cs
+        // Use the array of NSBonjourServices from Info.plist; however, in this list, append the domain and terminating period (usually ".local.")
+        static List<string> BrowseDomainProtocolList = new List<string>()
+        {
+            "_audioplayer-discovery._tcp.local.",
+            "_http._tcp.local.",
+            "_printer._tcp.local.",
+            "_apple-mobdev2._tcp.local.",
+        };
+
 #pragma warning disable RECS0165 // Asynchronous methods should return a Task instead of void
         static async void BrowseOnClicked(Label output)
 #pragma warning restore RECS0165 // Asynchronous methods should return a Task instead of void
@@ -56,6 +66,9 @@ namespace ZeroconfTest.Xam
             //{
                
             //});
+
+            // Xamarin iOS on iOS 14.5+ only: BrowseDomainsAsync() is not usable without this initialization
+            ZeroconfResolver.SetBrowseDomainProtocols(BrowseDomainProtocolList);
 
             responses = await ZeroconfResolver.BrowseDomainsAsync();
             foreach (var service in responses)
@@ -78,6 +91,8 @@ namespace ZeroconfTest.Xam
 
             //});
 
+            // Xamarin.iOS on iOS 14.5+ only: BrowseDomainsAsync() is not usable without this initialization
+            ZeroconfResolver.SetBrowseDomainProtocols(BrowseDomainProtocolList);
 
             var domains = await ZeroconfResolver.BrowseDomainsAsync();
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,12 +33,10 @@ stages:
     - script: nbgv cloud
       displayName: Set Version
 
-    - task: DotNetCoreCLI@2
-      inputs:
-        command: pack
-        packagesToPack: Zeroconf/Zeroconf.csproj
-        configuration: $(BuildConfiguration)
-        packDirectory: $(Build.ArtifactStagingDirectory)\Packages    
+    - task: VSBuild@1
+      inputs:    
+        solution: .\Zeroconf\Zeroconf.csproj
+        msbuildArgs: '/restore /m /t:Pack /p:PackageOutputPath=$(Build.ArtifactStagingDirectory)\Packages'
       displayName: Build / Pack
 
     - publish: $(Build.ArtifactStagingDirectory)\Packages

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+    "msbuild-sdks": {
+        "MSBuild.Sdk.Extras": "3.0.23"
+    }
+}


### PR DESCRIPTION
Uses iOS NSNetServiceBrowser/NSNetService instead of BSD sockets. Some items visible using raw sockets are not available in NSNetServiceBrowser and friends. Also, by definition, this code can only browse services it requests permission to see via Info.plist entries.