### PR TITLE
replace domain name in order to allow dots in service name

### DIFF
--- a/Zeroconf/ZeroconfResolver.cs
+++ b/Zeroconf/ZeroconfResolver.cs
@@ -126,7 +126,7 @@ namespace Zeroconf
                         || (options != null
                             && options.Protocols.Contains(ptrRec.RR.NAME))))
                 {
-                    z.DisplayName = ptrRec.PTRDNAME.Split('.')[0];
+                    z.DisplayName = ptrRec.PTRDNAME.Replace($".{ptrRec.RR.NAME}","");
                     dispNameSet = true;
                 }
 


### PR DESCRIPTION
Replace domain name with empty string in order to show service names with a dot correctly.