### PR TITLE
fix: multiple services by one host get now indexed by the SRV name, not the PTR name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ The easiest way to get started is to use the NuGet package.
 
 Current Build Status: [![Build Status](https://dev.azure.com/clairernovotny/GitBuilds/_apis/build/status/Zeroconf%20-%20CI?branchName=master)](https://dev.azure.com/clairernovotny/GitBuilds/_build/latest?definitionId=37)
 
+## Migration from <= v3.5.11 to >=v3.6
+
+The key of the dictionary `IZeroconfHost.Services` of type `IReadOnlyDictionary<string, IService>` that is returned by e.g. `ResolveAsync` changed.
+Instead of `IService.Name` which is the PTR record name, now the name from the SRV record is used which is called `ServiceName` in `IService`.
+This allows to return more than one service of the same type from the same host. If you used the key of this dictonary (e.g. `s.Key`) for iteration now use `s.Value.Name`.
+
 ## Usage 
 
 There's are two methods with a few optional parameters:

--- a/Zeroconf/ZeroConfResolver.Listener.cs
+++ b/Zeroconf/ZeroConfResolver.Listener.cs
@@ -89,7 +89,7 @@ namespace Zeroconf
                     {
                         foreach (var service in host.Services)
                         {
-                            var keyValue = new Tuple<string, string>(host.DisplayName, service.Key);
+                            var keyValue = new Tuple<string, string>(host.DisplayName, service.Value.Name);
                             if (discoveredHosts.Contains(keyValue))
                             {
                                 remainingHosts.Remove(keyValue);

--- a/Zeroconf/ZeroconfNetServiceBrowser.cs
+++ b/Zeroconf/ZeroconfNetServiceBrowser.cs
@@ -1,4 +1,4 @@
-#if __IOS__
+﻿#if __IOS__
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -75,7 +75,7 @@ namespace Zeroconf
                     foreach (var ipAddr in host.IPAddresses)
                     {
                         IntermediateResult b = new IntermediateResult();
-                        b.ServiceNameAndDomain = service.Key;
+                        b.ServiceNameAndDomain = service.Value.Name;
                         b.HostIPAndService = $"{ipAddr}: {BonjourBrowser.GetServiceType(service.Value.Name, includeTcpUdpDelimiter: false)}";
 
                         resultsList.Add(b);
@@ -83,7 +83,7 @@ namespace Zeroconf
                         // Simpleminded callback implementation
                         if (callback != null)
                         {
-                            callback(service.Key, ipAddr);
+                            callback(service.Value.Name, ipAddr);
                         }
                     }
                 }

--- a/Zeroconf/ZeroconfRecord.cs
+++ b/Zeroconf/ZeroconfRecord.cs
@@ -45,14 +45,15 @@ namespace Zeroconf
     public interface IService
     {
         /// <summary>
-        ///     Name
+        ///     This is the name retrieved from the PTR record
+        /// e.g. _http._tcp.local
         /// </summary>
         string Name { get; }
 
         /// <summary>
-        ///     Name
+        ///     This is the name retrieved from the SRV record e.g. myserver._http._tcp.local
         /// </summary>
-        string SrvName { get; }
+        string ServiceName { get; }
 
         /// <summary>
         ///     Port
@@ -159,7 +160,7 @@ namespace Zeroconf
 
         internal void AddService(IService service)
         {
-            services[service.SrvName] = service ?? throw new ArgumentNullException(nameof(service));
+            services[service.ServiceName] = service ?? throw new ArgumentNullException(nameof(service));
         }
     }
 
@@ -168,7 +169,7 @@ namespace Zeroconf
         readonly List<IReadOnlyDictionary<string, string>> properties = new List<IReadOnlyDictionary<string, string>>();
 
         public string Name { get; set; }
-        public string SrvName { get; set; }
+        public string ServiceName { get; set; }
         public int Port { get; set; }
         public int Ttl { get; set; }
 
@@ -178,7 +179,7 @@ namespace Zeroconf
         {
             var sb = new StringBuilder();
 
-            sb.Append($"Service: {Name} SRVName: {SrvName} Port: {Port}, TTL: {Ttl}, PropertySets: {properties.Count}");
+            sb.Append($"Service: {Name} ServiceName: {ServiceName} Port: {Port}, TTL: {Ttl}, PropertySets: {properties.Count}");
 
             if (properties.Any())
             {

--- a/Zeroconf/ZeroconfRecord.cs
+++ b/Zeroconf/ZeroconfRecord.cs
@@ -50,6 +50,11 @@ namespace Zeroconf
         string Name { get; }
 
         /// <summary>
+        ///     Name
+        /// </summary>
+        string SrvName { get; }
+
+        /// <summary>
         ///     Port
         /// </summary>
         int Port { get; }
@@ -154,7 +159,7 @@ namespace Zeroconf
 
         internal void AddService(IService service)
         {
-            services[service.Name] = service ?? throw new ArgumentNullException(nameof(service));
+            services[service.SrvName] = service ?? throw new ArgumentNullException(nameof(service));
         }
     }
 
@@ -163,6 +168,7 @@ namespace Zeroconf
         readonly List<IReadOnlyDictionary<string, string>> properties = new List<IReadOnlyDictionary<string, string>>();
 
         public string Name { get; set; }
+        public string SrvName { get; set; }
         public int Port { get; set; }
         public int Ttl { get; set; }
 
@@ -172,7 +178,7 @@ namespace Zeroconf
         {
             var sb = new StringBuilder();
 
-            sb.Append($"Service: {Name} Port: {Port}, TTL: {Ttl}, PropertySets: {properties.Count}");
+            sb.Append($"Service: {Name} SRVName: {SrvName} Port: {Port}, TTL: {Ttl}, PropertySets: {properties.Count}");
 
             if (properties.Any())
             {

--- a/Zeroconf/ZeroconfRecord.cs
+++ b/Zeroconf/ZeroconfRecord.cs
@@ -75,9 +75,9 @@ namespace Zeroconf
     /// <summary>
     ///     A ZeroConf record response
     /// </summary>
-    class ZeroconfHost : IZeroconfHost, IEquatable<ZeroconfHost>, IEquatable<IZeroconfHost>
+    internal class ZeroconfHost : IZeroconfHost, IEquatable<ZeroconfHost>, IEquatable<IZeroconfHost>
     {
-        readonly Dictionary<string, IService> services = new Dictionary<string, IService>();
+        private readonly Dictionary<string, IService> services = new Dictionary<string, IService>();
 
         public bool Equals(IZeroconfHost other)
         {
@@ -86,8 +86,16 @@ namespace Zeroconf
 
         public bool Equals(ZeroconfHost other)
         {
-            if (ReferenceEquals(null, other)) return false;
-            if (ReferenceEquals(this, other)) return true;
+            if (ReferenceEquals(null, other))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
             return string.Equals(Id, other.Id) && string.Equals(IPAddress, other.IPAddress);
         }
 
@@ -122,9 +130,21 @@ namespace Zeroconf
 
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != GetType()) return false;
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            if (obj.GetType() != GetType())
+            {
+                return false;
+            }
+
             return Equals((ZeroconfHost)obj);
         }
 
@@ -133,7 +153,7 @@ namespace Zeroconf
             unchecked
             {
                 var addressesHash = IPAddresses?.Aggregate(0, (current, address) => (current * 397) ^ address.GetHashCode()) ?? 0;
-                return ((Id != null ? Id.GetHashCode() : 0)*397) ^ addressesHash;
+                return ((Id != null ? Id.GetHashCode() : 0) * 397) ^ addressesHash;
             }
         }
 
@@ -144,16 +164,26 @@ namespace Zeroconf
         public override string ToString()
         {
             var sb = new StringBuilder();
-            sb.Append($"Id: {Id}, DisplayName: {DisplayName}, IPs: {string.Join(", ", IPAddresses)}, Services: {services.Count}");
+            sb.AppendLine("| ----------------------------------------------");
+            sb.AppendLine("| HOST");
+            sb.AppendLine("| ----------------------------------------------");
+            sb.AppendLine($"| Id: {Id}\n| DisplayName: {DisplayName}\n| IPs: {string.Join(", ", IPAddresses)}\n| Services: {services.Count}");
 
             if (services.Any())
             {
-                sb.AppendLine();
-                foreach (var svc in services)
+                var i = 0;
+                foreach (var service in services)
                 {
-                    sb.AppendLine(svc.Value.ToString());
+                    sb.AppendLine("\t| -------------------");
+                    sb.AppendLine($"\t| Service #{i++}");
+                    sb.AppendLine("\t| -------------------");
+                    sb.AppendLine(service.Value.ToString());
+                    sb.AppendLine("\t| -------------------");
                 }
+
             }
+
+            sb.AppendLine("| ---------------------------------------------");
 
             return sb.ToString();
         }
@@ -164,9 +194,9 @@ namespace Zeroconf
         }
     }
 
-    class Service : IService
+    internal class Service : IService
     {
-        readonly List<IReadOnlyDictionary<string, string>> properties = new List<IReadOnlyDictionary<string, string>>();
+        private readonly List<IReadOnlyDictionary<string, string>> properties = new List<IReadOnlyDictionary<string, string>>();
 
         public string Name { get; set; }
         public string ServiceName { get; set; }
@@ -179,23 +209,23 @@ namespace Zeroconf
         {
             var sb = new StringBuilder();
 
-            sb.Append($"Service: {Name} ServiceName: {ServiceName} Port: {Port}, TTL: {Ttl}, PropertySets: {properties.Count}");
+            sb.Append($"\t| Service: {Name}\n\t| ServiceName: {ServiceName}\n\t| Port: {Port}\n\t| TTL: {Ttl}\n\t| PropertySets: {properties.Count}");
 
             if (properties.Any())
             {
                 sb.AppendLine();
                 for (var i = 0; i < properties.Count; i++)
                 {
-                    sb.Append($"Begin Property Set #{i}");
+                    sb.AppendLine("\t\t| -------------------");
+                    sb.Append($"\t\t| Property Set #{i}");
                     sb.AppendLine();
-                    sb.AppendLine("-------------------");
+                    sb.AppendLine("\t\t| -------------------");
 
                     foreach (var kvp in properties[i])
                     {
-                        sb.Append($"{kvp.Key} = {kvp.Value}");
-                        sb.AppendLine();
+                        sb.AppendLine($"\t\t| {kvp.Key} = {kvp.Value}");
                     }
-                    sb.AppendLine("-------------------");
+                    sb.Append("\t\t| -------------------");
                 }
             }
 
@@ -205,7 +235,9 @@ namespace Zeroconf
         internal void AddPropertySet(IReadOnlyDictionary<string, string> set)
         {
             if (set == null)
+            {
                 throw new ArgumentNullException(nameof(set));
+            }
 
             properties.Add(set);
         }

--- a/Zeroconf/ZeroconfRecord.cs
+++ b/Zeroconf/ZeroconfRecord.cs
@@ -46,12 +46,12 @@ namespace Zeroconf
     {
         /// <summary>
         ///     This is the name retrieved from the PTR record
-        /// e.g. _http._tcp.local
+        /// e.g. _http._tcp.local.
         /// </summary>
         string Name { get; }
 
         /// <summary>
-        ///     This is the name retrieved from the SRV record e.g. myserver._http._tcp.local
+        ///     This is the name retrieved from the SRV record e.g. myserver._http._tcp.local.
         /// </summary>
         string ServiceName { get; }
 

--- a/Zeroconf/ZeroconfResolver.Async.cs
+++ b/Zeroconf/ZeroconfResolver.Async.cs
@@ -124,7 +124,7 @@ namespace Zeroconf
                 wrappedAction = (address, resp) =>
                 {
                     var zc = ResponseToZeroconf(resp, address, options);
-                    if (zc.Services.Any(s => options.Protocols.Contains(s.Key)))
+                    if (zc.Services.Any(s => options.Protocols.Contains(s.Value.Name)))
                     {
                         callback(zc);
                     }
@@ -138,7 +138,7 @@ namespace Zeroconf
                                  .ConfigureAwait(false);
 
             return dict.Select(pair => ResponseToZeroconf(pair.Value, pair.Key, options))
-                       .Where(zh => zh.Services.Any(s => options.Protocols.Contains(s.Key))) // Ensure we only return records that have matching services
+                       .Where(zh => zh.Services.Any(s => options.Protocols.Contains(s.Value.Name))) // Ensure we only return records that have matching services
                        .ToList();
         }
 

--- a/Zeroconf/ZeroconfResolver.cs
+++ b/Zeroconf/ZeroconfResolver.cs
@@ -142,7 +142,8 @@ namespace Zeroconf
 
                 var svc = new Service
                 {
-                    Name = srvRec.RR.NAME,
+                    Name = ptrRec.RR.NAME,
+                    SrvName = srvRec.RR.NAME,
                     Port = srvRec.PORT,
                     Ttl = (int)srvRec.RR.TTL,
 

--- a/Zeroconf/ZeroconfResolver.cs
+++ b/Zeroconf/ZeroconfResolver.cs
@@ -143,7 +143,7 @@ namespace Zeroconf
                 var svc = new Service
                 {
                     Name = ptrRec.RR.NAME,
-                    SrvName = srvRec.RR.NAME,
+                    ServiceName = srvRec.RR.NAME,
                     Port = srvRec.PORT,
                     Ttl = (int)srvRec.RR.TTL,
 

--- a/Zeroconf/ZeroconfResolver.cs
+++ b/Zeroconf/ZeroconfResolver.cs
@@ -142,7 +142,7 @@ namespace Zeroconf
 
                 var svc = new Service
                 {
-                    Name = ptrRec.RR.NAME,
+                    Name = srvRec.RR.NAME,
                     Port = srvRec.PORT,
                     Ttl = (int)srvRec.RR.TTL,
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.5",
+  "version": "3.6",
   "publicReleaseRefSpec": [
     "^refs/heads/main$", // we release out of master
     "^refs/heads/rel/v\\d+\\.\\d+" // we also release branches starting with rel/vN.N


### PR DESCRIPTION
This allows to announce and find multiple services of the same type e.g. _http._tcp by one server.

Fixes https://github.com/novotnyllc/Zeroconf/issues/198