### PR TITLE
Bugfix: ArgumentNullException on iOS 14.5+

### DIFF
--- a/Zeroconf/BonjourBrowser.cs
+++ b/Zeroconf/BonjourBrowser.cs
@@ -399,6 +399,7 @@ namespace Zeroconf
                 Service svc = new Service();
                 svc.Name = GetNsNetServiceName(nsNetService);
                 svc.Port = (int)nsNetService.Port;
+                svc.ServiceName = $"{nsNetService.Name}{nsNetService.Type}";
                 // svc.Ttl = is not available
 
                 NSData txtRecordData = nsNetService.GetTxtRecordData();

--- a/Zeroconf/BonjourBrowser.cs
+++ b/Zeroconf/BonjourBrowser.cs
@@ -399,7 +399,7 @@ namespace Zeroconf
                 Service svc = new Service();
                 svc.Name = GetNsNetServiceName(nsNetService);
                 svc.Port = (int)nsNetService.Port;
-                svc.ServiceName = $"{nsNetService.Name}{nsNetService.Type}";
+                svc.ServiceName = $"{nsNetService.Name}.{nsNetService.Type}{nsNetService.Domain}";
                 // svc.Ttl = is not available
 
                 NSData txtRecordData = nsNetService.GetTxtRecordData();


### PR DESCRIPTION
ServiceName property was never assigned so host.AddService(svc) throws ArgumentNullException. 