### PR TITLE
Ensure the BonjourBrowser sets ServiceName - iOS, Bug

### DIFF
--- a/Zeroconf/BonjourBrowser.cs
+++ b/Zeroconf/BonjourBrowser.cs
@@ -1,4 +1,4 @@
-﻿#if __IOS__
+#if __IOS__
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -399,6 +399,7 @@ namespace Zeroconf
                 Service svc = new Service();
                 svc.Name = GetNsNetServiceName(nsNetService);
                 svc.Port = (int)nsNetService.Port;
+                svc.ServiceName = GetNsNetServiceFullName(nsNetService);
                 // svc.Ttl = is not available
 
                 NSData txtRecordData = nsNetService.GetTxtRecordData();
@@ -483,6 +484,17 @@ namespace Zeroconf
         string GetNsNetServiceName(NSNetService service)
         {
             return $"{service.Type}{service.Domain}";
+        }
+
+        string GetNsNetServiceFullName(NSNetService service)
+        {
+            string serviceUniqueName = service.HostName;
+            // if the HostName includes the domain (usually does in the NSNetService)
+            if (serviceUniqueName.Contains(".")) { 
+                // remove the domain
+                serviceUniqueName = serviceUniqueName.Split(".")[0];
+            }
+            return $"{serviceUniqueName}.{service.Type}{service.Domain}";
         }
 
         string GetZeroconfHostKey(NSNetService service)

--- a/Zeroconf/ZeroconfRecord.cs
+++ b/Zeroconf/ZeroconfRecord.cs
@@ -190,7 +190,13 @@ namespace Zeroconf
 
         internal void AddService(IService service)
         {
-            services[service.ServiceName] = service ?? throw new ArgumentNullException(nameof(service));
+            if (service is null) {
+                throw new ArgumentNullException(nameof(service));
+            }
+            if (service.ServiceName is null) {
+                throw new ArgumentNullException(nameof(service.ServiceName));
+            }
+            services[service.ServiceName] = service;
         }
     }
 


### PR DESCRIPTION
The ServiceName was not being set on the ZeroconfRecord Service as part of the BonjourBrowser pipeline. This resulted in an obscure null key exception. See issue https://github.com/novotnyllc/Zeroconf/issues/244 for details.