### PR TITLE
Update NetworkInterface.cs

### DIFF
--- a/Zeroconf/NetworkInterface.cs
+++ b/Zeroconf/NetworkInterface.cs
@@ -28,7 +28,8 @@ namespace Zeroconf
             // populate list with all adapters if none specified
             if(netInterfacesToSendRequestOn == null || !netInterfacesToSendRequestOn.Any())
             {
-                netInterfacesToSendRequestOn = System.Net.NetworkInformation.NetworkInterface.GetAllNetworkInterfaces();
+                netInterfacesToSendRequestOn = System.Net.NetworkInformation.NetworkInterface.GetAllNetworkInterfaces()
+                                                .Where(inter => inter.Supports(NetworkInterfaceComponent.IPv4));
             }
                                     
             var tasks = netInterfacesToSendRequestOn


### PR DESCRIPTION
During development I got an IPv4 exception. It was the same exception as in https://github.com/novotnyllc/Zeroconf/issues/84.
The proposed solution in that issue fixed it. It will now only fetch the networkinterfaces which support IPv4.