### PR TITLE
IOS only: Add callback capability to BonjourBrowser and ResolveAsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,8 +211,8 @@ ResolverListener()
 
 ### Implementation Details
 
-The callback functions are based on a simple-minded implementation: they will be called only after each ScanTime interval has expired for each distinct
-protocol/mDNS service.
+The callback functions are based on a somewhat simple-minded implementation: if multiple protocols/mDNS services are requested, 
+callbacks will be called only after the ScanTime interval for the previous protocol has expired.
 
 The more protocols/mDNS services you resolve, the longer it takes the library to return: minimumTotalDelayTime = (nServices * ScanTime).
 

--- a/Zeroconf/BonjourBrowser.cs
+++ b/Zeroconf/BonjourBrowser.cs
@@ -1,4 +1,4 @@
-#if __IOS__
+﻿#if __IOS__
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -23,12 +23,21 @@ namespace Zeroconf
         HashSet<string> domainHash = new HashSet<string>();
 
         double netServiceResolveTimeout;
+        private Action<IZeroconfHost> zeroConfHostCallback;
 
         /// <summary>
         /// Implements iOS mDNS browse and resolve
         /// </summary>
         /// <param name="resolveTimeout">Time limit for NSNetService.Resolve() operation</param>
-        public BonjourBrowser(TimeSpan resolveTimeout = default(TimeSpan))
+        public BonjourBrowser(TimeSpan resolveTimeout = default(TimeSpan)) : this(resolveTimeout, null)
+        {
+        }
+        /// <summary>
+        /// Implements iOS mDNS browse and resolve
+        /// </summary>
+        /// <param name="resolveTimeout">Time limit for NSNetService.Resolve() operation</param>
+        /// <param name="callback">Returns host information as it becomes available.</param>
+        public BonjourBrowser(TimeSpan resolveTimeout = default(TimeSpan), Action<IZeroconfHost> callback = null)
         {
             netServiceBrowser.FoundDomain += Browser_FoundDomain;
             netServiceBrowser.DomainRemoved += Browser_DomainRemoved;
@@ -41,6 +50,7 @@ namespace Zeroconf
             netServiceBrowser.SearchStopped += Browser_SearchStopped;
 
             netServiceResolveTimeout = (resolveTimeout != default(TimeSpan)) ? resolveTimeout.TotalSeconds : 5D;
+            zeroConfHostCallback = callback;
         }
 
         private void Browser_FoundDomain(object sender, NSNetDomainEventArgs e)
@@ -123,6 +133,7 @@ namespace Zeroconf
                 lock (discoveredServiceDict)
                 {
                     discoveredServiceDict[serviceKey] = netService;
+                    CreateZeroconfHostRecord(netService);
                 }
             }
         }
@@ -353,11 +364,6 @@ namespace Zeroconf
         {
             Debug.WriteLine($"{nameof(ReturnZeroconfHostResults)}");
 
-            lock (zeroconfHostDict)
-            {
-                zeroconfHostDict.Clear();
-            }
-
             RefreshZeroconfHostDict();
 
             List<IZeroconfHost> hostList = new List<IZeroconfHost>();
@@ -387,53 +393,67 @@ namespace Zeroconf
 
             foreach (var nsNetService in nsNetServiceList)
             {
-                Debug.WriteLine($"{nameof(ReturnZeroconfHostResults)}: Name {nsNetService.Name} Type {nsNetService.Type} Domain {nsNetService.Domain} " +
-                    $"HostName {nsNetService.HostName} Port {nsNetService.Port}");
+                CreateZeroconfHostRecord(nsNetService);
+            }
+        }
 
-                // Obtain or create ZeroconfHost
+        private void CreateZeroconfHostRecord(NSNetService nsNetService)
+        {
+            Debug.WriteLine($"{nameof(ReturnZeroconfHostResults)}: Name {nsNetService.Name} Type {nsNetService.Type} Domain {nsNetService.Domain} " +
+                $"HostName {nsNetService.HostName} Port {nsNetService.Port}");
 
-                ZeroconfHost host = GetOrCreateZeroconfHost(nsNetService);
+            // Obtain or create ZeroconfHost
 
-                // Add service to ZeroconfHost record
+            ZeroconfHost host = GetOrCreateZeroconfHost(nsNetService);
 
-                Service svc = new Service();
-                svc.Name = GetNsNetServiceName(nsNetService);
-                svc.Port = (int)nsNetService.Port;
-                svc.ServiceName = GetNsNetServiceFullName(nsNetService);
-                // svc.Ttl = is not available
+            // Add service to ZeroconfHost record
 
-                NSData txtRecordData = nsNetService.GetTxtRecordData();
-                if (txtRecordData != null)
+            Service svc = new Service();
+            svc.Name = GetNsNetServiceName(nsNetService);
+            svc.Port = (int)nsNetService.Port;
+            svc.ServiceName = GetNsNetServiceFullName(nsNetService);
+            // svc.Ttl = is not available
+
+            NSData txtRecordData = nsNetService.GetTxtRecordData();
+            if (txtRecordData != null)
+            {
+                NSDictionary txtDict = NSNetService.DictionaryFromTxtRecord(txtRecordData);
+                if (txtDict != null)
                 {
-                    NSDictionary txtDict = NSNetService.DictionaryFromTxtRecord(txtRecordData);
-                    if (txtDict != null)
+                    if (txtDict.Count > 0)
                     {
-                        if (txtDict.Count > 0)
+                        foreach (var key in txtDict.Keys)
                         {
-                            foreach (var key in txtDict.Keys)
-                            {
-                                Debug.WriteLine($"{nameof(ReturnZeroconfHostResults)}: Key {key} Value {txtDict[key].ToString()}");
-                            }
-
-                            Dictionary<string, string> propertyDict = new Dictionary<string, string>();
-
-                            foreach (var key in txtDict.Keys)
-                            {
-                                propertyDict[key.ToString()] = txtDict[key].ToString();
-                            }
-                            svc.AddPropertySet(propertyDict);
+                            Debug.WriteLine($"{nameof(ReturnZeroconfHostResults)}: Key {key} Value {txtDict[key].ToString()}");
                         }
-                        else
+
+                        Dictionary<string, string> propertyDict = new Dictionary<string, string>();
+
+                        foreach (var key in txtDict.Keys)
                         {
-                            Debug.WriteLine($"{nameof(ReturnZeroconfHostResults)}: Service.DictionaryFromTxtRecord has 0 entries");
+                            propertyDict[key.ToString()] = txtDict[key].ToString();
                         }
+                        svc.AddPropertySet(propertyDict);
                     }
                     else
                     {
-                        Debug.WriteLine($"{nameof(ReturnZeroconfHostResults)}: Service.DictionaryFromTxtRecord returned null");
+                        Debug.WriteLine($"{nameof(ReturnZeroconfHostResults)}: Service.DictionaryFromTxtRecord has 0 entries");
                     }
                 }
-
+                else
+                {
+                    Debug.WriteLine($"{nameof(ReturnZeroconfHostResults)}: Service.DictionaryFromTxtRecord returned null");
+                }
+            }
+            if (!host.Services.TryGetValue(svc.ServiceName, out var previousService)
+                || previousService.ToString() != svc.ToString()) // An explicit comparison would be more efficient but overkill here
+            {
+                host.AddService(svc);
+                zeroConfHostCallback?.Invoke(host);
+            }
+            else
+            {
+                // Just in case the service data has changed and wasn't caught in the comparison
                 host.AddService(svc);
             }
         }

--- a/Zeroconf/BonjourBrowser.cs
+++ b/Zeroconf/BonjourBrowser.cs
@@ -18,9 +18,9 @@ namespace Zeroconf
     {
         NSNetServiceBrowser netServiceBrowser = new NSNetServiceBrowser();
 
-        Dictionary<string, NSNetService> discoveredServiceDict = new Dictionary<string, NSNetService>();
-        Dictionary<string, ZeroconfHost> zeroconfHostDict = new Dictionary<string, ZeroconfHost>();
-        HashSet<string> domainHash = new HashSet<string>();
+        readonly Dictionary<string, NSNetService> discoveredServiceDict = new Dictionary<string, NSNetService>();
+        readonly Dictionary<string, ZeroconfHost> zeroconfHostDict = new Dictionary<string, ZeroconfHost>();
+        readonly HashSet<string> domainHash = new HashSet<string>();
 
         double netServiceResolveTimeout;
         private Action<IZeroconfHost> zeroConfHostCallback;

--- a/Zeroconf/BonjourBrowser.cs
+++ b/Zeroconf/BonjourBrowser.cs
@@ -29,13 +29,6 @@ namespace Zeroconf
         /// Implements iOS mDNS browse and resolve
         /// </summary>
         /// <param name="resolveTimeout">Time limit for NSNetService.Resolve() operation</param>
-        public BonjourBrowser(TimeSpan resolveTimeout = default(TimeSpan)) : this(resolveTimeout, null)
-        {
-        }
-        /// <summary>
-        /// Implements iOS mDNS browse and resolve
-        /// </summary>
-        /// <param name="resolveTimeout">Time limit for NSNetService.Resolve() operation</param>
         /// <param name="callback">Returns host information as it becomes available.</param>
         public BonjourBrowser(TimeSpan resolveTimeout = default(TimeSpan), Action<IZeroconfHost> callback = null)
         {
@@ -446,15 +439,10 @@ namespace Zeroconf
                 }
             }
             if (!host.Services.TryGetValue(svc.ServiceName, out var previousService)
-                || previousService.ToString() != svc.ToString()) // An explicit comparison would be more efficient but overkill here
+                || !svc.Equals(previousService))
             {
                 host.AddService(svc);
                 zeroConfHostCallback?.Invoke(host);
-            }
-            else
-            {
-                // Just in case the service data has changed and wasn't caught in the comparison
-                host.AddService(svc);
             }
         }
 

--- a/Zeroconf/Zeroconf.csproj
+++ b/Zeroconf/Zeroconf.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;netstandard2.0;net48;xamarinios10;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;netstandard2.0;net48;net10.0-ios;net10.0-maccatalyst;net10.0-android</TargetFrameworks>
     <Copyright>© Claire Novotny 2016-2024</Copyright>
     <PackageTags>zeroconf;bonjour;mdns;service;discovery;maui;xamarin;netstandard;universal</PackageTags>
     <Authors>Claire Novotny</Authors>
@@ -40,10 +40,5 @@
       </AssemblyAttribute>
     </ItemGroup>
   </Target>
-  
-  <ItemGroup Condition=" '$(UseMaui)' == 'true' " >
-    <PackageReference Update="Microsoft.Maui.Controls.Compatibility" Version="8.0.100" />
-    <PackageReference Update="Microsoft.Maui.Controls" Version="8.0.100" />
-  </ItemGroup>
   
 </Project>

--- a/Zeroconf/ZeroconfNetServiceBrowser.cs
+++ b/Zeroconf/ZeroconfNetServiceBrowser.cs
@@ -23,7 +23,15 @@ namespace Zeroconf
 
             // Seems you must reuse the one BonjourBrowser (which is really an NSNetServiceBrowser)... multiple instances do not play well together
 
-            BonjourBrowser bonjourBrowser = new BonjourBrowser(options.ScanTime);
+            BonjourBrowser bonjourBrowser = new BonjourBrowser(options.ScanTime, 
+                callback != null ? (host) =>
+                {
+                    if (host.Services.Keys.Any(serviceKey => options.Protocols.Any(protocol => serviceKey.Contains(protocol))))
+                    {
+                        callback.Invoke(host);
+                    }
+                }
+            : null);
 
             foreach (var protocol in options.Protocols)
             {
@@ -34,11 +42,11 @@ namespace Zeroconf
                 bonjourBrowser.StopServiceSearch();
 
                 // Simpleminded callback implementation
-                var results = bonjourBrowser.ReturnZeroconfHostResults();
-                foreach (var result in results.Where(r => r.Services.ContainsKey(protocol)))
-                {
-                    callback?.Invoke(result);
-                }
+                //var results = bonjourBrowser.ReturnZeroconfHostResults();
+                //foreach (var result in results.Where(r => r.Services.Keys.Any(k => k.Contains(protocol))))
+                //{
+                //    callback?.Invoke(result);
+                //}
             }
 
             return bonjourBrowser.ReturnZeroconfHostResults();

--- a/Zeroconf/ZeroconfNetServiceBrowser.cs
+++ b/Zeroconf/ZeroconfNetServiceBrowser.cs
@@ -40,13 +40,6 @@ namespace Zeroconf
                 await Task.Delay(options.ScanTime, cancellationToken).ConfigureAwait(false);
 
                 bonjourBrowser.StopServiceSearch();
-
-                // Simpleminded callback implementation
-                //var results = bonjourBrowser.ReturnZeroconfHostResults();
-                //foreach (var result in results.Where(r => r.Services.Keys.Any(k => k.Contains(protocol))))
-                //{
-                //    callback?.Invoke(result);
-                //}
             }
 
             return bonjourBrowser.ReturnZeroconfHostResults();

--- a/Zeroconf/ZeroconfRecord.cs
+++ b/Zeroconf/ZeroconfRecord.cs
@@ -200,7 +200,7 @@ namespace Zeroconf
         }
     }
 
-    internal class Service : IService
+    internal class Service : IService, IEquatable<Service>, IEquatable<IService>
     {
         private readonly List<IReadOnlyDictionary<string, string>> properties = new List<IReadOnlyDictionary<string, string>>();
 
@@ -210,6 +210,40 @@ namespace Zeroconf
         public int Ttl { get; set; }
 
         public IReadOnlyList<IReadOnlyDictionary<string, string>> Properties => properties;
+
+        public bool Equals(IService other)
+        {
+            return Equals(other as Service);
+        }
+        public bool Equals(Service other)
+        {
+            if (ReferenceEquals(null, other))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            if (!string.Equals(Name, other.Name) || !string.Equals(ServiceName, other.ServiceName) || Port != other.Port || Ttl != other.Ttl)
+            {
+                return false;
+            }
+            if (Properties.Count != other.Properties.Count)
+            {
+                return false;
+            }
+            for(int i=0; i<Properties.Count; i++)
+            {
+                if (!Properties[i].SequenceEqual(other.Properties[i]))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
 
         public override string ToString()
         {


### PR DESCRIPTION
Existing callback was filtering out all notifications (bug #274), and was only done after discovery was stopped (feature #275).