### PR TITLE
Use the cancellation token to properly cancel the UdpClient.ReceiveAsync() task

### DIFF
--- a/Zeroconf/NetworkInterface.cs
+++ b/Zeroconf/NetworkInterface.cs
@@ -130,8 +130,13 @@ namespace Zeroconf
                                                    {
                                                        while (!Volatile.Read(ref shouldCancel))
                                                        {
+#if NET6_0_OR_GREATER
                                                            var res = await client.ReceiveAsync(cancellationToken)
                                                                                  .ConfigureAwait(false);
+#else
+                                                           var res = await client.ReceiveAsync()
+                                                                                 .ConfigureAwait(false);
+#endif
 
                                                            onResponse(res.RemoteEndPoint.Address, res.Buffer);
                                                        }

--- a/Zeroconf/NetworkInterface.cs
+++ b/Zeroconf/NetworkInterface.cs
@@ -130,7 +130,7 @@ namespace Zeroconf
                                                    {
                                                        while (!Volatile.Read(ref shouldCancel))
                                                        {
-                                                           var res = await client.ReceiveAsync()
+                                                           var res = await client.ReceiveAsync(cancellationToken)
                                                                                  .ConfigureAwait(false);
 
                                                            onResponse(res.RemoteEndPoint.Address, res.Buffer);


### PR DESCRIPTION
Use the cancellation token to properly cancel the UdpClient.ReceiveAsync(CancellationToken cancellationToken) task
* https://github.com/novotnyllc/Zeroconf/blob/bd4bd55e044a9aa4b8656741214c989a5ee50ded/Zeroconf/NetworkInterface.cs#L133

Solves this issue: https://github.com/novotnyllc/Zeroconf/issues/281#issue-3231487602